### PR TITLE
Tyrian entry point redesign

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,4 @@
 
 # Run from root.
 
-sbt clean update compile test +tyrian/publishLocal
+sbt clean update compile test +publishLocal

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,13 @@
+# Warning!!
+
+Normally these examples are bound to the last published version, but Tyrian is undergoing an overhaul, and these examples are being used for testing.
+
+As such, they are temporarily pointing at the in-development version of Tyrian.
+
+For the examples looking at the currently published versions, please refer to the release commit:
+
+[https://github.com/PurpleKingdomGames/tyrian/tree/5f4f65246e3d9db7cc490e4dc17d097c13c78fd8/examples](https://github.com/PurpleKingdomGames/tyrian/tree/5f4f65246e3d9db7cc490e4dc17d097c13c78fd8/examples)
+
 # Tyrian Examples
 
 Here are a number of examples.

--- a/examples/bootstrap/src/main/scala/example/Main.scala
+++ b/examples/bootstrap/src/main/scala/example/Main.scala
@@ -1,36 +1,44 @@
 package example
 
 import org.scalajs.dom.document
-import tyrian.Html
 import tyrian.Html._
-import tyrian.Tyrian
+import tyrian._
 
 object Main:
   opaque type Model = Int
 
-  def main(args: Array[String]): Unit =
-    Tyrian.start(document.getElementById("myapp"), init, update, view)
+  def init: (Model, Cmd[Msg]) = (0, Cmd.Empty)
 
-  def init: Model = 0
-
-  def update(msg: Msg, model: Model): Model =
+  def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
     msg match
-      case Msg.Increment => model + 1
-      case Msg.Decrement => model - 1
+      case Msg.Increment => (model + 1, Cmd.Empty)
+      case Msg.Decrement => (model - 1, Cmd.Empty)
 
   def view(model: Model): Html[Msg] =
-    div(`class`("container"))(
-      div(`class`("row"))(
-        div(`class`("col bodyText"), styles("text-align" -> "right"))(
+    div(`class` := "container")(
+      div(`class` := "row")(
+        div(`class` := "col bodyText", styles("text-align" -> "right"))(
           button(onClick(Msg.Decrement))(text("-"))
         ),
-        div(`class`("col bodyText"), styles("text-align" -> "center"))(
+        div(`class` := "col bodyText", styles("text-align" -> "center"))(
           text(model.toString)
         ),
-        div(`class`("col bodyText"), styles("text-align" -> "left"))(
+        div(`class` := "col bodyText", styles("text-align" -> "left"))(
           button(onClick(Msg.Increment))(text("+"))
         )
       )
+    )
+
+  def subscriptions(model: Model): Sub[Msg] =
+    Sub.Empty
+
+  def main(args: Array[String]): Unit =
+    Tyrian.start(
+      document.getElementById("myapp"),
+      init,
+      update,
+      view,
+      subscriptions
     )
 
 enum Msg:

--- a/examples/build.sbt
+++ b/examples/build.sbt
@@ -121,11 +121,11 @@ lazy val tyrianExamplesProject =
     .settings(
       logo := s"Tyrian Examples (v${version.value})",
       usefulTasks := Seq(
-        UsefulTask("", "buildExamples", "Cleans and builds all examples"),
-        UsefulTask("", "cleanAll", "Cleans all examples"),
-        UsefulTask("", "compileAll", "Compiles all examples"),
-        UsefulTask("", "fastOptAll", "Compiles all examples to JS"),
-        UsefulTask("", "code", "Launch VSCode")
+        UsefulTask("a", "buildExamples", "Cleans and builds all examples"),
+        UsefulTask("b", "cleanAll", "Cleans all examples"),
+        UsefulTask("c", "compileAll", "Compiles all examples"),
+        UsefulTask("d", "fastOptAll", "Compiles all examples to JS"),
+        UsefulTask("e", "code", "Launch VSCode")
       ) ++ makeCmds(exampleProjects),
       logoColor        := scala.Console.MAGENTA,
       aliasColor       := scala.Console.BLUE,

--- a/examples/bundler/src/main/scala/example/Main.scala
+++ b/examples/bundler/src/main/scala/example/Main.scala
@@ -1,28 +1,36 @@
 package example
 
 import org.scalajs.dom.document
-import tyrian.Html
 import tyrian.Html._
-import tyrian.Tyrian
+import tyrian._
 
 object Main:
   opaque type Model = Int
 
-  def main(args: Array[String]): Unit =
-    Tyrian.start(document.getElementById("myapp"), init, update, view)
+  def init: (Model, Cmd[Msg]) = (0, Cmd.Empty)
 
-  def init: Model = 0
-
-  def update(msg: Msg, model: Model): Model =
+  def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
     msg match
-      case Msg.Increment => model + 1
-      case Msg.Decrement => model - 1
+      case Msg.Increment => (model + 1, Cmd.Empty)
+      case Msg.Decrement => (model - 1, Cmd.Empty)
 
   def view(model: Model): Html[Msg] =
     div()(
       button(onClick(Msg.Decrement))(text("-")),
       div()(text(model.toString)),
       button(onClick(Msg.Increment))(text("+"))
+    )
+
+  def subscriptions(model: Model): Sub[Msg] =
+    Sub.Empty
+
+  def main(args: Array[String]): Unit =
+    Tyrian.start(
+      document.getElementById("myapp"),
+      init,
+      update,
+      view,
+      subscriptions
     )
 
 enum Msg:

--- a/examples/counter/src/main/scala/example/Main.scala
+++ b/examples/counter/src/main/scala/example/Main.scala
@@ -1,28 +1,36 @@
 package example
 
 import org.scalajs.dom.document
-import tyrian.Html
 import tyrian.Html._
-import tyrian.Tyrian
+import tyrian._
 
 object Main:
   opaque type Model = Int
 
-  def main(args: Array[String]): Unit =
-    Tyrian.start(document.getElementById("myapp"), init, update, view)
+  def init: (Model, Cmd[Msg]) = (0, Cmd.Empty)
 
-  def init: Model = 0
-
-  def update(msg: Msg, model: Model): Model =
+  def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
     msg match
-      case Msg.Increment => model + 1
-      case Msg.Decrement => model - 1
+      case Msg.Increment => (model + 1, Cmd.Empty)
+      case Msg.Decrement => (model - 1, Cmd.Empty)
 
   def view(model: Model): Html[Msg] =
     div()(
       button(onClick(Msg.Decrement))(text("-")),
       div()(text(model.toString)),
       button(onClick(Msg.Increment))(text("+"))
+    )
+
+  def subscriptions(model: Model): Sub[Msg] =
+    Sub.Empty
+
+  def main(args: Array[String]): Unit =
+    Tyrian.start(
+      document.getElementById("myapp"),
+      init,
+      update,
+      view,
+      subscriptions
     )
 
 enum Msg:

--- a/examples/counter/src/main/scala/example/Main.scala
+++ b/examples/counter/src/main/scala/example/Main.scala
@@ -1,13 +1,15 @@
 package example
 
+import org.scalajs.dom.Element
 import org.scalajs.dom.document
 import tyrian.Html._
 import tyrian._
 
-object Main:
-  opaque type Model = Int
+object Main extends TyrianApp[Msg, Model]:
 
-  def init: (Model, Cmd[Msg]) = (0, Cmd.Empty)
+  def container: Element = document.getElementById("myapp")
+
+  def init: (Model, Cmd[Msg]) = (Model.init, Cmd.Empty)
 
   def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
     msg match
@@ -24,14 +26,13 @@ object Main:
   def subscriptions(model: Model): Sub[Msg] =
     Sub.Empty
 
-  def main(args: Array[String]): Unit =
-    Tyrian.start(
-      document.getElementById("myapp"),
-      init,
-      update,
-      view,
-      subscriptions
-    )
+opaque type Model = Int
+object Model:
+  def init: Model = 0
+
+  extension (i: Model)
+    def +(other: Int): Model = i + other
+    def -(other: Int): Model = i - other
 
 enum Msg:
   case Increment, Decrement

--- a/examples/field/src/main/scala/example/Main.scala
+++ b/examples/field/src/main/scala/example/Main.scala
@@ -1,30 +1,26 @@
 package example
 
 import org.scalajs.dom.document
-import tyrian.Html
 import tyrian.Html._
-import tyrian.Style
-import tyrian.Tyrian
+import tyrian._
 
 object Main:
-  def main(args: Array[String]): Unit =
-    Tyrian.start(document.getElementById("myapp"), init, update, view)
 
   type Model = String
 
-  def init: Model = ""
+  def init: (Model, Cmd[Msg]) = ("", Cmd.Empty)
 
   enum Msg:
     case NewContent(content: String) extends Msg
 
-  def update(msg: Msg, model: Model): Model =
+  def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
     msg match
-      case Msg.NewContent(content) => content
+      case Msg.NewContent(content) => (content, Cmd.Empty)
 
   def view(model: Model): Html[Msg] =
     div()(
       input(
-        placeholder("Text to reverse"),
+        placeholder := "Text to reverse",
         onInput(s => Msg.NewContent(s)),
         myStyle
       ),
@@ -38,4 +34,16 @@ object Main:
       "padding"    -> "10px 0",
       "font-size"  -> "2em",
       "text-align" -> "center"
+    )
+
+  def subscriptions(model: Model): Sub[Msg] =
+    Sub.Empty
+
+  def main(args: Array[String]): Unit =
+    Tyrian.start(
+      document.getElementById("myapp"),
+      init,
+      update,
+      view,
+      subscriptions
     )

--- a/examples/http/src/main/scala/example/Main.scala
+++ b/examples/http/src/main/scala/example/Main.scala
@@ -22,7 +22,7 @@ object Main:
       h2()(text(model.topic)),
       button(onClick(Msg.MorePlease))(text("more please")),
       br,
-      img(src(model.gifUrl))
+      img(src := model.gifUrl)
     )
 
   def subscriptions(model: Model): Sub[Msg] =

--- a/examples/subcomponents/src/main/scala/example/Main.scala
+++ b/examples/subcomponents/src/main/scala/example/Main.scala
@@ -1,9 +1,8 @@
 package example
 
 import org.scalajs.dom.document
-import tyrian.Html
 import tyrian.Html._
-import tyrian.Tyrian
+import tyrian._
 
 object Main:
 
@@ -14,23 +13,25 @@ object Main:
     case Remove                           extends Msg
     case Modify(i: Int, msg: Counter.Msg) extends Msg
 
-  def init: Model =
-    Nil
+  def init: (Model, Cmd[Msg]) =
+    (Nil, Cmd.Empty)
 
-  def update(msg: Msg, model: Model): Model =
+  def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
     msg match
       case Msg.Insert =>
-        Counter.init :: model
+        (Counter.init :: model, Cmd.Empty)
 
       case Msg.Remove =>
         model match
-          case Nil    => Nil
-          case _ :: t => t
+          case Nil    => (Nil, Cmd.Empty)
+          case _ :: t => (t, Cmd.Empty)
 
       case Msg.Modify(id, m) =>
-        model.zipWithIndex.map { case (c, i) =>
+        val updated = model.zipWithIndex.map { case (c, i) =>
           if i == id then Counter.update(m, c) else c
         }
+
+        (updated, Cmd.Empty)
 
   def view(model: Model): Html[Msg] =
     val counters = model.zipWithIndex.map { case (c, i) =>
@@ -44,8 +45,17 @@ object Main:
 
     div()(elems: _*)
 
+  def subscriptions(model: Model): Sub[Msg] =
+    Sub.Empty
+
   def main(args: Array[String]): Unit =
-    Tyrian.start(document.getElementById("myapp"), init, update, view)
+    Tyrian.start(
+      document.getElementById("myapp"),
+      init,
+      update,
+      view,
+      subscriptions
+    )
 
 object Counter:
 

--- a/sandbox/src/main/scala/example/Sandbox.scala
+++ b/sandbox/src/main/scala/example/Sandbox.scala
@@ -1,6 +1,6 @@
 package example
 
-import tyrian.{Html, Tyrian}
+import tyrian._
 import tyrian.Html._
 import org.scalajs.dom.document
 
@@ -12,30 +12,30 @@ object Sandbox:
     case Remove                           extends Msg
     case Modify(i: Int, msg: Counter.Msg) extends Msg
 
-  def init: Model =
-    Model.init
+  def init: (Model, Cmd[Msg]) =
+    (Model.init, Cmd.Empty)
 
-  def update(msg: Msg, model: Model): Model =
+  def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
     msg match
       case Msg.NewContent(content) =>
-        model.copy(field = content)
+        (model.copy(field = content), Cmd.Empty)
 
       case Msg.Insert =>
-        model.copy(components = Counter.init :: model.components)
+        (model.copy(components = Counter.init :: model.components), Cmd.Empty)
 
       case Msg.Remove =>
         val cs = model.components match
           case Nil    => Nil
           case _ :: t => t
 
-        model.copy(components = cs)
+        (model.copy(components = cs), Cmd.Empty)
 
       case Msg.Modify(id, m) =>
         val cs = model.components.zipWithIndex.map { case (c, i) =>
           if i == id then Counter.update(m, c) else c
         }
 
-        model.copy(components = cs)
+        (model.copy(components = cs), Cmd.Empty)
 
   def view(model: Model): Html[Msg] =
     val counters = model.components.zipWithIndex.map { case (c, i) =>
@@ -64,8 +64,11 @@ object Sandbox:
       "text-align" -> "center"
     )
 
+  def subscriptions(model: Model): Sub[Msg] =
+    Sub.Empty
+
   def main(args: Array[String]): Unit =
-    Tyrian.start(document.getElementById("myapp"), init, update, view)
+    Tyrian.start(document.getElementById("myapp"), init, update, view, subscriptions)
 
 object Counter:
 

--- a/sandbox/src/main/scala/example/Sandbox.scala
+++ b/sandbox/src/main/scala/example/Sandbox.scala
@@ -3,14 +3,11 @@ package example
 import tyrian._
 import tyrian.Html._
 import org.scalajs.dom.document
+import org.scalajs.dom.Element
 
-object Sandbox:
+object Sandbox extends TyrianApp[Msg, Model]:
 
-  enum Msg:
-    case NewContent(content: String)      extends Msg
-    case Insert                           extends Msg
-    case Remove                           extends Msg
-    case Modify(i: Int, msg: Counter.Msg) extends Msg
+  def container: Element = document.getElementById("myapp")
 
   def init: (Model, Cmd[Msg]) =
     (Model.init, Cmd.Empty)
@@ -67,8 +64,11 @@ object Sandbox:
   def subscriptions(model: Model): Sub[Msg] =
     Sub.Empty
 
-  def main(args: Array[String]): Unit =
-    Tyrian.start(document.getElementById("myapp"), init, update, view, subscriptions)
+enum Msg:
+  case NewContent(content: String)      extends Msg
+  case Insert                           extends Msg
+  case Remove                           extends Msg
+  case Modify(i: Int, msg: Counter.Msg) extends Msg
 
 object Counter:
 

--- a/tyrian/js/src/main/scala/tyrian/Tyrian.scala
+++ b/tyrian/js/src/main/scala/tyrian/Tyrian.scala
@@ -20,37 +20,6 @@ object Tyrian:
     *   state transition function
     * @param view
     *   view function
-    * @tparam Model
-    *   Type of model
-    * @tparam Msg
-    *   Type of messages
-    * @return
-    *   The tyrian runtime
-    */
-  def start[Model, Msg](
-      node: Element,
-      init: Model,
-      update: (Msg, Model) => Model,
-      view: Model => Html[Msg]
-  ): Unit =
-    new TyrianRuntime(
-      (init, Cmd.Empty),
-      (msg: Msg, m: Model) => (update(msg, m), Cmd.Empty),
-      view,
-      _ => Sub.Empty,
-      node
-    ).start()
-
-  /** Computes the initial state of the given application, renders it on the given DOM element, and listens to user
-    * actions
-    * @param node
-    *   the DOM element to mount the app to
-    * @param init
-    *   initial state
-    * @param update
-    *   state transition function
-    * @param view
-    *   view function
     * @param subscriptions
     *   subscriptions function
     * @tparam Model

--- a/tyrian/js/src/main/scala/tyrian/TyrianApp.scala
+++ b/tyrian/js/src/main/scala/tyrian/TyrianApp.scala
@@ -1,0 +1,18 @@
+package tyrian
+
+import org.scalajs.dom.Element
+
+trait TyrianApp[Msg, Model]:
+
+  def container: Element
+
+  def init: (Model, Cmd[Msg])
+
+  def update(msg: Msg, model: Model): (Model, Cmd[Msg])
+
+  def view(model: Model): Html[Msg]
+
+  def subscriptions(model: Model): Sub[Msg]
+
+  def main(args: Array[String]): Unit =
+    Tyrian.start(container, init, update, view, subscriptions)


### PR DESCRIPTION
This PR:

- Deprecates the "simple" constructor as it's misleading
- Adds an Indigo-style entry point trait (not necessarily less code but you get more compiler help with app requirements)