### PR TITLE
Fixed #34: Launch mechanism similar to Indigo's

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -117,10 +117,11 @@ lazy val sandbox =
     .withoutSuffixFor(JSPlatform)
     .dependsOn(tyrian)
     .settings(
-      name                            := "sandbox",
-      scalaJSUseMainModuleInitializer := true,
+      neverPublish,
+      commonSettings,
+      name := "sandbox",
       scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
-      neverPublish
+      scalacOptions -= "-language:strictEquality"
     )
 
 lazy val indigoSandbox =
@@ -131,14 +132,15 @@ lazy val indigoSandbox =
     .dependsOn(tyrianIndigoBridge)
     .settings(
       neverPublish,
-      name                            := "Indigo Sandbox",
-      scalaJSUseMainModuleInitializer := true,
+      commonSettings,
+      name := "Indigo Sandbox",
       scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
       libraryDependencies ++= Seq(
         "io.indigoengine" %%% "indigo"            % Dependancies.indigoVersion,
         "io.indigoengine" %%% "indigo-extras"     % Dependancies.indigoVersion,
         "io.indigoengine" %%% "indigo-json-circe" % Dependancies.indigoVersion
-      )
+      ),
+      scalacOptions -= "-language:strictEquality"
     )
 
 lazy val jsdocs =

--- a/examples/bootstrap/index.html
+++ b/examples/bootstrap/index.html
@@ -9,7 +9,7 @@
 
 <body>
   <div id="myapp"></div>
-  <script type="module" src="./target/scala-3.1.1/bootstrap-fastopt/main.js"></script>
+  <script type="module" src="./tyrianapp.js"></script>
 </body>
 
 </html>

--- a/examples/bootstrap/src/main/scala/example/Main.scala
+++ b/examples/bootstrap/src/main/scala/example/Main.scala
@@ -1,13 +1,14 @@
 package example
 
-import org.scalajs.dom.document
-import tyrian.Html._
-import tyrian._
+import tyrian.Html.*
+import tyrian.*
 
-object Main:
-  opaque type Model = Int
+import scala.scalajs.js.annotation.*
 
-  def init: (Model, Cmd[Msg]) = (0, Cmd.Empty)
+@JSExportTopLevel("TyrianApp")
+object Main extends TyrianApp[Msg, Model]:
+
+  def init(flags: Map[String, String]): (Model, Cmd[Msg]) = (0, Cmd.Empty)
 
   def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
     msg match
@@ -32,14 +33,7 @@ object Main:
   def subscriptions(model: Model): Sub[Msg] =
     Sub.Empty
 
-  def main(args: Array[String]): Unit =
-    Tyrian.start(
-      document.getElementById("myapp"),
-      init,
-      update,
-      view,
-      subscriptions
-    )
+type Model = Int
 
 enum Msg:
   case Increment, Decrement

--- a/examples/bootstrap/tyrianapp.js
+++ b/examples/bootstrap/tyrianapp.js
@@ -1,0 +1,3 @@
+import {TyrianApp} from './target/scala-3.1.1/bootstrap-fastopt.js';
+
+TyrianApp.launch("myapp");

--- a/examples/build.sbt
+++ b/examples/build.sbt
@@ -21,7 +21,6 @@ lazy val commonSettings: Seq[sbt.Def.Setting[_]] = Seq(
     "io.indigoengine" %%% "tyrian" % tyrianVersion
   ),
   testFrameworks += new TestFramework("munit.Framework"),
-  scalaJSUseMainModuleInitializer := true,
   scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
   crossScalaVersions := Seq(scala3Version),
   scalafixOnCompile  := true,
@@ -46,7 +45,8 @@ lazy val bundler =
       Compile / npmDependencies += "snabbdom" -> "3.0.1",
       // Source maps seem to be broken with bundler
       Compile / fastOptJS / scalaJSLinkerConfig ~= { _.withSourceMap(false) },
-      Compile / fullOptJS / scalaJSLinkerConfig ~= { _.withSourceMap(false) }
+      Compile / fullOptJS / scalaJSLinkerConfig ~= { _.withSourceMap(false) },
+      scalaJSUseMainModuleInitializer := true
     )
 
 lazy val clock =

--- a/examples/bundler/src/main/scala/example/Main.scala
+++ b/examples/bundler/src/main/scala/example/Main.scala
@@ -1,13 +1,14 @@
 package example
 
-import org.scalajs.dom.document
-import tyrian.Html._
-import tyrian._
+import tyrian.Html.*
+import tyrian.*
 
-object Main:
-  opaque type Model = Int
+import scala.scalajs.js.annotation.*
 
-  def init: (Model, Cmd[Msg]) = (0, Cmd.Empty)
+@JSExportTopLevel("TyrianApp")
+object Main extends TyrianApp[Msg, Model]:
+
+  def init(flags: Map[String, String]): (Model, Cmd[Msg]) = (0, Cmd.Empty)
 
   def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
     msg match
@@ -25,13 +26,9 @@ object Main:
     Sub.Empty
 
   def main(args: Array[String]): Unit =
-    Tyrian.start(
-      document.getElementById("myapp"),
-      init,
-      update,
-      view,
-      subscriptions
-    )
+    launch("myapp")
+
+type Model = Int
 
 enum Msg:
   case Increment, Decrement

--- a/examples/clock/index.html
+++ b/examples/clock/index.html
@@ -8,7 +8,7 @@
 
 <body>
   <div id="myapp"></div>
-  <script type="module" src="./target/scala-3.1.1/clock-fastopt/main.js"></script>
+  <script type="module" src="./tyrianapp.js"></script>
 </body>
 
 </html>

--- a/examples/clock/src/main/scala/example/Main.scala
+++ b/examples/clock/src/main/scala/example/Main.scala
@@ -1,20 +1,17 @@
 package example
 
-import org.scalajs.dom.document
-import tyrian.Cmd
-import tyrian.Html
-import tyrian.Html._
-import tyrian.Sub
-import tyrian.Tyrian
+import tyrian.Html.*
+import tyrian.*
 
 import scalajs.js
 import concurrent.duration.DurationInt
 
-object Clock:
+import scala.scalajs.js.annotation.*
 
-  opaque type Model = js.Date
+@JSExportTopLevel("TyrianApp")
+object Main extends TyrianApp[Msg, Model]:
 
-  def init: (Model, Cmd[Msg]) =
+  def init(flags: Map[String, String]): (Model, Cmd[Msg]) =
     (new js.Date(), Cmd.Empty)
 
   def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
@@ -43,13 +40,6 @@ object Clock:
   def subscriptions(model: Model): Sub[Msg] =
     Sub.every(1.second, "clock-ticks").map(Msg.apply)
 
-  def main(args: Array[String]): Unit =
-    Tyrian.start(
-      document.getElementById("myapp"),
-      init,
-      update,
-      view,
-      subscriptions
-    )
+type Model = js.Date
 
 final case class Msg(newTime: js.Date)

--- a/examples/clock/tyrianapp.js
+++ b/examples/clock/tyrianapp.js
@@ -1,0 +1,5 @@
+import {
+  TyrianApp
+} from './target/scala-3.1.1/clock-fastopt.js';
+
+TyrianApp.launch("myapp");

--- a/examples/counter/index.html
+++ b/examples/counter/index.html
@@ -8,7 +8,7 @@
 
 <body>
   <div id="myapp"></div>
-  <script type="module" src="./target/scala-3.1.1/counter-fastopt/main.js"></script>
+  <script type="module" src="./tyrianapp.js"></script>
 </body>
 
 </html>

--- a/examples/counter/src/main/scala/example/Main.scala
+++ b/examples/counter/src/main/scala/example/Main.scala
@@ -1,15 +1,15 @@
 package example
 
-import org.scalajs.dom.Element
-import org.scalajs.dom.document
-import tyrian.Html._
-import tyrian._
+import tyrian.Html.*
+import tyrian.*
 
+import scala.scalajs.js.annotation.*
+
+@JSExportTopLevel("TyrianApp")
 object Main extends TyrianApp[Msg, Model]:
 
-  def container: Element = document.getElementById("myapp")
-
-  def init: (Model, Cmd[Msg]) = (Model.init, Cmd.Empty)
+  def init(flags: Map[String, String]): (Model, Cmd[Msg]) =
+    (Model.init, Cmd.Empty)
 
   def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
     msg match

--- a/examples/counter/tyrianapp.js
+++ b/examples/counter/tyrianapp.js
@@ -1,0 +1,5 @@
+import {
+  TyrianApp
+} from './target/scala-3.1.1/counter-fastopt.js';
+
+TyrianApp.launch("myapp");

--- a/examples/field/index.html
+++ b/examples/field/index.html
@@ -8,7 +8,7 @@
 
 <body>
   <div id="myapp"></div>
-  <script type="module" src="./target/scala-3.1.1/field-fastopt/main.js"></script>
+  <script type="module" src="./tyrianapp.js"></script>
 </body>
 
 </html>

--- a/examples/field/src/main/scala/example/Main.scala
+++ b/examples/field/src/main/scala/example/Main.scala
@@ -1,17 +1,14 @@
 package example
 
-import org.scalajs.dom.document
-import tyrian.Html._
-import tyrian._
+import tyrian.Html.*
+import tyrian.*
 
-object Main:
+import scala.scalajs.js.annotation.*
 
-  type Model = String
+@JSExportTopLevel("TyrianApp")
+object Main extends TyrianApp[Msg, Model]:
 
-  def init: (Model, Cmd[Msg]) = ("", Cmd.Empty)
-
-  enum Msg:
-    case NewContent(content: String) extends Msg
+  def init(flags: Map[String, String]): (Model, Cmd[Msg]) = ("", Cmd.Empty)
 
   def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
     msg match
@@ -39,11 +36,7 @@ object Main:
   def subscriptions(model: Model): Sub[Msg] =
     Sub.Empty
 
-  def main(args: Array[String]): Unit =
-    Tyrian.start(
-      document.getElementById("myapp"),
-      init,
-      update,
-      view,
-      subscriptions
-    )
+type Model = String
+
+enum Msg:
+  case NewContent(content: String) extends Msg

--- a/examples/field/tyrianapp.js
+++ b/examples/field/tyrianapp.js
@@ -1,0 +1,5 @@
+import {
+  TyrianApp
+} from './target/scala-3.1.1/field-fastopt.js';
+
+TyrianApp.launch("myapp");

--- a/examples/http/index.html
+++ b/examples/http/index.html
@@ -8,7 +8,7 @@
 
 <body>
   <div id="myapp"></div>
-  <script type="module" src="./target/scala-3.1.1/http-fastopt/main.js"></script>
+  <script type="module" src="./tyrianapp.js"></script>
 </body>
 
 </html>

--- a/examples/http/src/main/scala/example/Main.scala
+++ b/examples/http/src/main/scala/example/Main.scala
@@ -1,14 +1,16 @@
 package example
 
-import io.circe.parser._
-import org.scalajs.dom.document
-import tyrian.Html._
-import tyrian._
-import tyrian.http._
+import io.circe.parser.*
+import tyrian.Html.*
+import tyrian.*
+import tyrian.http.*
 
-object Main:
+import scala.scalajs.js.annotation.*
 
-  def init: (Model, Cmd[Msg]) =
+@JSExportTopLevel("TyrianApp")
+object Main extends TyrianApp[Msg, Model]:
+
+  def init(flags: Map[String, String]): (Model, Cmd[Msg]) =
     (Model("cats", "waiting.gif"), HttpHelper.getRandomGif("cats"))
 
   def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
@@ -27,17 +29,6 @@ object Main:
 
   def subscriptions(model: Model): Sub[Msg] =
     Sub.Empty
-
-  def main(args: Array[String]): Unit =
-    Tyrian.start(
-      document.getElementById("myapp"),
-      init,
-      update,
-      view,
-      subscriptions
-    )
-
-end Main
 
 enum Msg:
   case MorePlease                 extends Msg

--- a/examples/http/tyrianapp.js
+++ b/examples/http/tyrianapp.js
@@ -1,0 +1,5 @@
+import {
+  TyrianApp
+} from './target/scala-3.1.1/http-fastopt.js';
+
+TyrianApp.launch("myapp");

--- a/examples/indigo/index.html
+++ b/examples/indigo/index.html
@@ -8,7 +8,7 @@
 
 <body>
   <div id="myapp"></div>
-  <script type="module" src="./target/scala-3.1.1/indigo-bridge-fastopt/main.js"></script>
+  <script type="module" src="./tyrianapp.js"></script>
 </body>
 
 </html>

--- a/examples/indigo/src/main/scala/example/Main.scala
+++ b/examples/indigo/src/main/scala/example/Main.scala
@@ -1,24 +1,21 @@
 package example
 
 import example.game.MyAwesomeGame
-import org.scalajs.dom.document
-import tyrian.Html._
-import tyrian._
+import tyrian.Html.*
+import tyrian.*
 import tyrian.cmds.Logger
 
-object Main:
+import scala.scalajs.js.annotation.*
+
+@JSExportTopLevel("TyrianApp")
+object Main extends TyrianApp[Msg, Model]:
 
   val gameDivId1: String    = "my-game-1"
   val gameDivId2: String    = "my-game-2"
   val gameId1: IndigoGameId = IndigoGameId("reverse")
   val gameId2: IndigoGameId = IndigoGameId("combine")
 
-  enum Msg:
-    case NewContent(content: String) extends Msg
-    case StartIndigo                 extends Msg
-    case IndigoReceive(msg: String)  extends Msg
-
-  def init: (Model, Cmd[Msg]) =
+  def init(flags: Map[String, String]): (Model, Cmd[Msg]) =
     (Model.init, Cmd.Emit(Msg.StartIndigo))
 
   def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
@@ -100,14 +97,10 @@ object Main:
       CSS.`text-align`("center")
     )
 
-  def main(args: Array[String]): Unit =
-    Tyrian.start(
-      document.getElementById("myapp"),
-      init,
-      update,
-      view,
-      subscriptions
-    )
+enum Msg:
+  case NewContent(content: String) extends Msg
+  case StartIndigo                 extends Msg
+  case IndigoReceive(msg: String)  extends Msg
 
 final case class Model(bridge: TyrianIndigoBridge[String], field: String)
 object Model:

--- a/examples/indigo/src/main/scala/example/game/GameScene.scala
+++ b/examples/indigo/src/main/scala/example/game/GameScene.scala
@@ -1,7 +1,7 @@
 package example.game
 
-import indigo._
-import indigo.scenes._
+import indigo.*
+import indigo.scenes.*
 
 final case class GameScene(clockwise: Boolean) extends Scene[Unit, Unit, Unit]:
 
@@ -42,10 +42,8 @@ final case class GameScene(clockwise: Boolean) extends Scene[Unit, Unit, Unit]:
       viewModel: Unit
   ): Outcome[SceneUpdateFragment] =
     val rotateAmount =
-      if clockwise then
-        Radians.fromSeconds(context.running * 0.25)
-      else
-        Radians(-Radians.fromSeconds(context.running * 0.25).toDouble)
+      if clockwise then Radians.fromSeconds(context.running * 0.25)
+      else Radians(-Radians.fromSeconds(context.running * 0.25).toDouble)
 
     Outcome(
       SceneUpdateFragment(

--- a/examples/indigo/src/main/scala/example/game/MyAwesomeGame.scala
+++ b/examples/indigo/src/main/scala/example/game/MyAwesomeGame.scala
@@ -1,11 +1,13 @@
 package example.game
 
-import indigo._
-import indigo.scenes._
+import indigo.*
+import indigo.scenes.*
 import tyrian.TyrianSubSystem
 
-final case class MyAwesomeGame(tyrianSubSystem: TyrianSubSystem[String], clockwise: Boolean)
-    extends IndigoGame[Unit, Unit, Unit, Unit]:
+final case class MyAwesomeGame(
+    tyrianSubSystem: TyrianSubSystem[String],
+    clockwise: Boolean
+) extends IndigoGame[Unit, Unit, Unit, Unit]:
 
   def initialScene(bootData: Unit): Option[SceneName] =
     None
@@ -53,7 +55,9 @@ final case class MyAwesomeGame(tyrianSubSystem: TyrianSubSystem[String], clockwi
       model: Unit
   ): GlobalEvent => Outcome[Unit] =
     case tyrianSubSystem.TyrianEvent.Receive(msg) =>
-      IndigoLogger.consoleLog(s"(Indigo) from tyrian: [${tyrianSubSystem.indigoGameId.getOrElse(" ")}] " + msg)
+      IndigoLogger.consoleLog(
+        s"(Indigo) from tyrian: [${tyrianSubSystem.indigoGameId.getOrElse(" ")}] " + msg
+      )
       val e =
         if clockwise then tyrianSubSystem.send(msg.reverse)
         else tyrianSubSystem.send(msg + "_" + msg)

--- a/examples/indigo/tyrianapp.js
+++ b/examples/indigo/tyrianapp.js
@@ -1,0 +1,5 @@
+import {
+  TyrianApp
+} from './target/scala-3.1.1/indigo-bridge-fastopt.js';
+
+TyrianApp.launch("myapp");

--- a/examples/mario/index.html
+++ b/examples/mario/index.html
@@ -116,7 +116,7 @@
     <span id="player-lives"> 5</span>
     <div id="item-container"></div>
     <span id="player-score">  0</span>
-    <script type="module" src="./target/scala-3.1.1/mario-fastopt/main.js"></script>
+    <script type="module" src="./tyrianapp.js"></script>
 </div>
 </body>
 </html>

--- a/examples/mario/src/main/scala/Effects.scala
+++ b/examples/mario/src/main/scala/Effects.scala
@@ -1,6 +1,6 @@
 package mario
 
-import mario.Main._
+import mario.Main.*
 import org.scalajs.dom
 import org.scalajs.dom.KeyboardEvent
 import org.scalajs.dom.document
@@ -43,7 +43,7 @@ object Effects {
   val UNDER_FRONT_MARIO  = (true, true)
   val UNDER_BEHIND_MARIO = (false, true)
 
-  def touchPressedSub(model: Model): Sub[Msg] =
+  def touchPressedSub(model: Mario): Sub[Msg] =
     Sub.fromEvent[TouchEvent, Msg]("touchstart", dom.window) { event =>
       val (posX, posY) =
         modelPositionScreen(window.innerWidth, window.innerHeight, model)
@@ -55,7 +55,7 @@ object Effects {
         case _                  => Some(Msg.ArrowUpPressed)
     }
 
-  def touchReleasedSub(model: Model): Sub[Msg] =
+  def touchReleasedSub(model: Mario): Sub[Msg] =
     Sub.fromEvent[TouchEvent, Msg]("touchend", dom.window) { event =>
       val (posX, posY) =
         modelPositionScreen(window.innerWidth, window.innerHeight, model)

--- a/examples/mario/src/main/scala/Main.scala
+++ b/examples/mario/src/main/scala/Main.scala
@@ -1,20 +1,20 @@
 package mario
 
-import org.scalajs.dom.document
 import org.scalajs.dom.window
-import tyrian.Html._
-import tyrian.Sub._
-import tyrian._
+import tyrian.Html.*
+import tyrian.Sub.*
+import tyrian.*
 
-object Main:
+import scala.scalajs.js.annotation.*
 
-  type Model = Mario
+@JSExportTopLevel("TyrianApp")
+object Main extends TyrianApp[Msg, Mario]:
 
-  def init: (Model, Cmd[Msg]) =
+  def init(flags: Map[String, String]): (Mario, Cmd[Msg]) =
     (Mario(0, 0, 0, 0, Direction.Right), Cmd.Empty)
 
-  def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
-    import Mario._
+  def update(msg: Msg, model: Mario): (Mario, Cmd[Msg]) =
+    import Mario.*
     msg match
       case Msg.ArrowUpPressed if model.y == 0.0 =>
         val newModel = (jump andThen applyPhysics)(model)
@@ -42,7 +42,7 @@ object Main:
       case _ =>
         (model, Cmd.Empty)
 
-  def subscriptions(model: Model): Sub[Msg] =
+  def subscriptions(model: Mario): Sub[Msg] =
     Sub.Batch(
       Effects.keyPressSub(37).map[Msg](_ => Msg.ArrowLeftPressed),
       Effects.keyPressSub(39).map(_ => Msg.ArrowRightPressed),
@@ -54,7 +54,7 @@ object Main:
       Effects.touchReleasedSub(model)
     )
 
-  def view(model: Model): Html[Msg] =
+  def view(model: Mario): Html[Msg] =
     val (posX, posY) =
       modelPositionScreen(window.innerWidth, window.innerHeight, model)
 
@@ -77,20 +77,11 @@ object Main:
   def modelPositionScreen(
       screenX: Double,
       screenY: Double,
-      model: Model
+      model: Mario
   ): (Double, Double) =
     val posX = ((screenX / 2) * 100) / 300 + model.x
     val posY = ((screenY - 200) * 100) / 300 - model.y
     (posX, posY)
-
-  def main(args: Array[String]): Unit =
-    Tyrian.start(
-      document.querySelector("#mario"),
-      init,
-      update,
-      view,
-      subscriptions
-    )
 
 end Main
 

--- a/examples/mario/tyrianapp.js
+++ b/examples/mario/tyrianapp.js
@@ -1,0 +1,5 @@
+import {
+  TyrianApp
+} from './target/scala-3.1.1/mario-fastopt.js';
+
+TyrianApp.launch("mario");

--- a/examples/mill/counter/src/example/Main.scala
+++ b/examples/mill/counter/src/example/Main.scala
@@ -1,22 +1,20 @@
 package example
 
-import org.scalajs.dom.document
-import tyrian.Html
-import tyrian.Html._
-import tyrian.Tyrian
+import tyrian.Html.*
+import tyrian._
 
-object Main:
-  opaque type Model = Int
+import scala.scalajs.js.annotation.*
 
-  def main(args: Array[String]): Unit =
-    Tyrian.start(document.getElementById("myapp"), init, update, view)
+@JSExportTopLevel("TyrianApp")
+object Main extends TyrianApp[Msg, Model]:
 
-  def init: Model = 0
+  def init(flags: Map[String, String]): (Model, Cmd[Msg]) =
+    (0, Cmd.Empty)
 
-  def update(msg: Msg, model: Model): Model =
+  def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
     msg match
-      case Msg.Increment => model + 1
-      case Msg.Decrement => model - 1
+      case Msg.Increment => (model + 1, Cmd.Empty)
+      case Msg.Decrement => (model - 1, Cmd.Empty)
 
   def view(model: Model): Html[Msg] =
     div()(
@@ -24,6 +22,11 @@ object Main:
       div()(text(model.toString)),
       button(onClick(Msg.Increment))(text("+"))
     )
+
+  def subscriptions(model: Model): Sub[Msg] =
+    Sub.Empty
+
+type Model = Int
 
 enum Msg:
   case Increment, Decrement

--- a/examples/mill/index.html
+++ b/examples/mill/index.html
@@ -8,7 +8,7 @@
 
 <body>
   <div id="myapp"></div>
-  <script type="module" src="./out/counter/fastOpt.dest/out.js"></script>
+  <script type="module" src="./tyrianapp.js"></script>
 </body>
 
 </html>

--- a/examples/mill/tyrianapp.js
+++ b/examples/mill/tyrianapp.js
@@ -1,0 +1,3 @@
+import {TyrianApp} from './out/counter/fastOpt.dest/out.js';
+
+TyrianApp.launch("myapp");

--- a/examples/server-examples/spa/src/main/scala/example/Main.scala
+++ b/examples/server-examples/spa/src/main/scala/example/Main.scala
@@ -5,9 +5,12 @@ import tyrian.Html.*
 import tyrian.*
 import tyrian.http.*
 
-object Main:
+import scala.scalajs.js.annotation.*
 
-  def init: (Model, Cmd[Msg]) =
+@JSExportTopLevel("TyrianApp")
+object Main extends TyrianApp[Msg, Model]:
+
+  def init(flags: Map[String, String]): (Model, Cmd[Msg]) =
     (Model(""), Cmd.Empty)
 
   def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
@@ -41,15 +44,7 @@ object Main:
     Sub.Empty
 
   def main(args: Array[String]): Unit =
-    Tyrian.start(
-      document.getElementById("myapp"),
-      init,
-      update,
-      view,
-      subscriptions
-    )
-
-end Main
+    launch("myapp")
 
 enum Msg:
   case SendText                  extends Msg

--- a/examples/subcomponents/index.html
+++ b/examples/subcomponents/index.html
@@ -8,7 +8,7 @@
 
 <body>
   <div id="myapp"></div>
-  <script type="module" src="./target/scala-3.1.1/subcomponents-fastopt/main.js"></script>
+  <script type="module" src="./tyrianapp.js"></script>
 </body>
 
 </html>

--- a/examples/subcomponents/src/main/scala/example/Main.scala
+++ b/examples/subcomponents/src/main/scala/example/Main.scala
@@ -1,19 +1,14 @@
 package example
 
-import org.scalajs.dom.document
-import tyrian.Html._
-import tyrian._
+import tyrian.Html.*
+import tyrian.*
 
-object Main:
+import scala.scalajs.js.annotation.*
 
-  opaque type Model = List[Counter.Model]
+@JSExportTopLevel("TyrianApp")
+object Main extends TyrianApp[Msg, Model]:
 
-  enum Msg:
-    case Insert                           extends Msg
-    case Remove                           extends Msg
-    case Modify(i: Int, msg: Counter.Msg) extends Msg
-
-  def init: (Model, Cmd[Msg]) =
+  def init(flags: Map[String, String]): (Model, Cmd[Msg]) =
     (Nil, Cmd.Empty)
 
   def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
@@ -22,19 +17,19 @@ object Main:
         (Counter.init :: model, Cmd.Empty)
 
       case Msg.Remove =>
-        model match
+        model.toList match
           case Nil    => (Nil, Cmd.Empty)
           case _ :: t => (t, Cmd.Empty)
 
       case Msg.Modify(id, m) =>
-        val updated = model.zipWithIndex.map { case (c, i) =>
+        val updated = model.toList.zipWithIndex.map { case (c, i) =>
           if i == id then Counter.update(m, c) else c
         }
 
         (updated, Cmd.Empty)
 
   def view(model: Model): Html[Msg] =
-    val counters = model.zipWithIndex.map { case (c, i) =>
+    val counters = model.toList.zipWithIndex.map { case (c, i) =>
       Counter.view(c).map(msg => Msg.Modify(i, msg))
     }
 
@@ -48,14 +43,12 @@ object Main:
   def subscriptions(model: Model): Sub[Msg] =
     Sub.Empty
 
-  def main(args: Array[String]): Unit =
-    Tyrian.start(
-      document.getElementById("myapp"),
-      init,
-      update,
-      view,
-      subscriptions
-    )
+type Model = List[Counter.Model]
+
+enum Msg:
+  case Insert                           extends Msg
+  case Remove                           extends Msg
+  case Modify(i: Int, msg: Counter.Msg) extends Msg
 
 object Counter:
 

--- a/examples/subcomponents/tyrianapp.js
+++ b/examples/subcomponents/tyrianapp.js
@@ -1,0 +1,5 @@
+import {
+  TyrianApp
+} from './target/scala-3.1.1/subcomponents-fastopt.js';
+
+TyrianApp.launch("myapp");

--- a/examples/websocket/index.html
+++ b/examples/websocket/index.html
@@ -8,7 +8,7 @@
 
 <body>
   <div id="myapp"></div>
-  <script type="module" src="./target/scala-3.1.1/websocket-fastopt/main.js"></script>
+  <script type="module" src="./tyrianapp.js"></script>
 </body>
 
 </html>

--- a/examples/websocket/src/main/scala/example/Main.scala
+++ b/examples/websocket/src/main/scala/example/Main.scala
@@ -1,16 +1,15 @@
 package example
 
-import org.scalajs.dom.Element
-import org.scalajs.dom.document
-import tyrian.Html._
-import tyrian._
-import tyrian.websocket._
+import tyrian.Html.*
+import tyrian.*
+import tyrian.websocket.*
 
+import scala.scalajs.js.annotation.*
+
+@JSExportTopLevel("TyrianApp")
 object Main extends TyrianApp[Msg, Model]:
 
-  def container: Element = document.getElementById("myapp")
-
-  def init: (Model, Cmd[Msg]) =
+  def init(flags: Map[String, String]): (Model, Cmd[Msg]) =
     (Model.init, Cmd.Empty)
 
   def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
@@ -21,7 +20,7 @@ object Main extends TyrianApp[Msg, Model]:
 
       case Msg.ToSocket(message) =>
         println("Sent: " + message)
-        (model, model.echoSocket.send(message))
+        (model, model.echoSocket.publish(message))
 
   def view(model: Model): Html[Msg] =
     div(

--- a/examples/websocket/tyrianapp.js
+++ b/examples/websocket/tyrianapp.js
@@ -1,0 +1,5 @@
+import {
+  TyrianApp
+} from './target/scala-3.1.1/websocket-fastopt.js';
+
+TyrianApp.launch("myapp");

--- a/indigo-sandbox/index.html
+++ b/indigo-sandbox/index.html
@@ -8,7 +8,7 @@
 
 <body>
   <div id="myapp"></div>
-  <script type="module" src="./.js/target/scala-3.1.1/indigo-sandbox-fastopt/main.js"></script>
+  <script type="module" src="./tyrianapp.js"></script>
 </body>
 
 </html>

--- a/indigo-sandbox/src/main/scala/example/IndigoSandbox.scala
+++ b/indigo-sandbox/src/main/scala/example/IndigoSandbox.scala
@@ -1,27 +1,22 @@
 package example
 
-import tyrian._
-import tyrian.Html._
-import org.scalajs.dom.document
 import example.game.MyAwesomeGame
+import org.scalajs.dom.document
+import tyrian.Html.*
+import tyrian.*
 import tyrian.cmds.Logger
 
-object IndigoSandbox:
+import scala.scalajs.js.annotation.*
+
+@JSExportTopLevel("TyrianApp")
+object IndigoSandbox extends TyrianApp[Msg, Model]:
 
   val gameDivId1: String = "my-game-1"
   val gameDivId2: String = "my-game-2"
   val gameId1: IndigoGameId = IndigoGameId("reverse")
   val gameId2: IndigoGameId = IndigoGameId("combine")
 
-  enum Msg:
-    case NewContent(content: String)      extends Msg
-    case Insert                           extends Msg
-    case Remove                           extends Msg
-    case Modify(i: Int, msg: Counter.Msg) extends Msg
-    case StartIndigo                      extends Msg
-    case IndigoReceive(msg: String)       extends Msg
-
-  def init: (Model, Cmd[Msg]) =
+  def init(flags: Map[String, String]): (Model, Cmd[Msg]) =
     (Model.init, Cmd.Emit(Msg.StartIndigo))
 
   def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
@@ -119,8 +114,13 @@ object IndigoSandbox:
       CSS.`text-align`("center")
     )
 
-  def main(args: Array[String]): Unit =
-    Tyrian.start(document.getElementById("myapp"), init, update, view, subscriptions)
+enum Msg:
+  case NewContent(content: String)      extends Msg
+  case Insert                           extends Msg
+  case Remove                           extends Msg
+  case Modify(i: Int, msg: Counter.Msg) extends Msg
+  case StartIndigo                      extends Msg
+  case IndigoReceive(msg: String)       extends Msg
 
 object Counter:
 

--- a/indigo-sandbox/tyrianapp.js
+++ b/indigo-sandbox/tyrianapp.js
@@ -1,0 +1,3 @@
+import {TyrianApp} from './.js/target/scala-3.1.1/indigo-sandbox-fastopt.js';
+
+TyrianApp.launch("myapp");

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -8,7 +8,7 @@
 
 <body>
   <div id="myapp"></div>
-  <script type="module" src="./.js/target/scala-3.1.1/sandbox-fastopt/main.js"></script>
+  <script type="module" src="./tyrianapp.js"></script>
 </body>
 
 </html>

--- a/sandbox/src/main/scala/example/Sandbox.scala
+++ b/sandbox/src/main/scala/example/Sandbox.scala
@@ -1,17 +1,17 @@
 package example
 
-import tyrian._
-import tyrian.Html._
-import tyrian.websocket._
-import org.scalajs.dom.document
-import org.scalajs.dom.Element
+import tyrian.Html.*
+import tyrian.*
+import tyrian.cmds.Logger
+import tyrian.websocket.*
 
+import scala.scalajs.js.annotation.*
+
+@JSExportTopLevel("TyrianApp")
 object Sandbox extends TyrianApp[Msg, Model]:
 
-  def container: Element = document.getElementById("myapp")
-
-  def init: (Model, Cmd[Msg]) =
-    (Model.init, Cmd.Empty)
+  def init(flags: Map[String, String]): (Model, Cmd[Msg]) =
+    (Model.init, Logger.info(flags.toString))
 
   def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
     msg match

--- a/sandbox/tyrianapp.js
+++ b/sandbox/tyrianapp.js
@@ -1,0 +1,3 @@
+import {TyrianApp} from './.js/target/scala-3.1.1/sandbox-fastopt.js';
+
+TyrianApp.launch("myapp", {"message": "Hello, Tyrian!"});

--- a/tyrian/js/src/main/scala/tyrian/TyrianApp.scala
+++ b/tyrian/js/src/main/scala/tyrian/TyrianApp.scala
@@ -22,5 +22,8 @@ trait TyrianApp[Msg, Model]:
   def launch(containerId: String, flags: scala.scalajs.js.Dictionary[String]): Unit =
     ready(containerId, flags.toMap)
 
+  def launch(containerId: String, flags: Map[String, String]): Unit =
+    ready(containerId, flags)
+
   private def ready(parentElementId: String, flags: Map[String, String]): Unit =
     Tyrian.start(document.getElementById(parentElementId), init(flags), update, view, subscriptions)

--- a/tyrian/js/src/main/scala/tyrian/TyrianApp.scala
+++ b/tyrian/js/src/main/scala/tyrian/TyrianApp.scala
@@ -1,12 +1,12 @@
 package tyrian
 
-import org.scalajs.dom.Element
+import org.scalajs.dom.document
+
+import scala.scalajs.js.annotation._
 
 trait TyrianApp[Msg, Model]:
 
-  def container: Element
-
-  def init: (Model, Cmd[Msg])
+  def init(flags: Map[String, String]): (Model, Cmd[Msg])
 
   def update(msg: Msg, model: Model): (Model, Cmd[Msg])
 
@@ -14,5 +14,13 @@ trait TyrianApp[Msg, Model]:
 
   def subscriptions(model: Model): Sub[Msg]
 
-  def main(args: Array[String]): Unit =
-    Tyrian.start(container, init, update, view, subscriptions)
+  @JSExport
+  def launch(containerId: String): Unit =
+    ready(containerId, Map[String, String]())
+
+  @JSExport
+  def launch(containerId: String, flags: scala.scalajs.js.Dictionary[String]): Unit =
+    ready(containerId, flags.toMap)
+
+  private def ready(parentElementId: String, flags: Map[String, String]): Unit =
+    Tyrian.start(document.getElementById(parentElementId), init(flags), update, view, subscriptions)


### PR DESCRIPTION
Rather than just embedding your app as a script, you would now launch it, thus allowing you to pass in the container id and `String->String` flags (like Indigo does - think command line args).

Might be worth noting that aside from being much less clever, this is straight up stolen from Elm. It essentially changes the `init` function from a value `(Model, Cmd[Msg])` to a function `Map[String, String] => (Model, Cmd[Msg])` allowing you to read the flags at initialisation time and set your model accordingly.