### PR TITLE
WebSocket: add keep-alive support

### DIFF
--- a/sandbox/src/main/scala/example/Sandbox.scala
+++ b/sandbox/src/main/scala/example/Sandbox.scala
@@ -37,7 +37,7 @@ object Sandbox extends TyrianApp[Msg, Model]:
 
       case Msg.WebSocketStatus(Status.ConnectionError(err)) =>
         println(s"Failed to open WebSocket connection: $err")
-        (model, Cmd.Empty)
+        (model.copy(error = Some(err)), Cmd.Empty)
 
       case Msg.WebSocketStatus(Status.Connected(ws)) =>
         (model.copy(echoSocket = Some(ws)), Cmd.Empty)

--- a/sandbox/src/main/scala/example/Sandbox.scala
+++ b/sandbox/src/main/scala/example/Sandbox.scala
@@ -104,8 +104,8 @@ object Sandbox extends TyrianApp[Msg, Model]:
         case WebSocketEvent.Open =>
           Msg.FromSocket("<no message - socket opened>")
 
-        case WebSocketEvent.Close =>
-          Msg.FromSocket("<no message - socket closed>")
+        case WebSocketEvent.Close(code, reason) =>
+          Msg.FromSocket(s"<socket closed> - code: $code, reason: $reason")
       }
     }
 

--- a/sandbox/src/main/scala/example/Sandbox.scala
+++ b/sandbox/src/main/scala/example/Sandbox.scala
@@ -39,7 +39,7 @@ object Sandbox extends TyrianApp[Msg, Model]:
         WebSocket.connect(
           address = model.socketUrl,
           onOpenMessage = "Connect me!",
-          keepAliveMessage = Some("Heartbeat")
+          keepAliveSettings = KeepAliveSettings.default
         ) match
         case Left(err) => (model.copy(error = Some(err)), Cmd.Empty)
         case Right(ws) => (model.copy(echoSocket = Some(ws)), Cmd.Empty)

--- a/tyrian/js/src/main/scala/tyrian/Task.scala
+++ b/tyrian/js/src/main/scala/tyrian/Task.scala
@@ -65,6 +65,9 @@ object Task:
   /** A task that is a fire and forget side effect */
   final case class SideEffect(thunk: () => Unit) extends Task[Nothing, Unit]
 
+  /** A task that suspends the side-effect of producing A. If it fails, an error message is returned */
+  final case class Delay[A](thunk: () => A) extends Task[String, A]
+
   /** A task that succeeded with the given `value` */
   final case class Succeeded[A](value: A) extends Task[Nothing, A]
 

--- a/tyrian/js/src/main/scala/tyrian/runtime/TaskRunner.scala
+++ b/tyrian/js/src/main/scala/tyrian/runtime/TaskRunner.scala
@@ -2,6 +2,8 @@ package tyrian.runtime
 
 import tyrian.Task
 
+import scala.util.control.NonFatal
+
 object TaskRunner:
 
   def asObserver[Err, Success](notifier: Either[Err, Success] => Unit): Task.Observer[Err, Success] =
@@ -13,6 +15,7 @@ object TaskRunner:
   def execTask[Err, Success](task: Task[Err, Success], notifier: Either[Err, Success] => Unit): Unit =
     task match
       case Task.SideEffect(thunk)         => thunk()
+      case Task.Delay(thunk)              => try { Right(thunk()) } catch { case NonFatal(e) => Left(e.getMessage) }
       case Task.Succeeded(value)          => notifier(Right(value))
       case Task.Failed(error)             => notifier(Left(error))
       case Task.RunObservable(observable) => observable.run(asObserver(notifier))

--- a/tyrian/js/src/main/scala/tyrian/runtime/TaskRunner.scala
+++ b/tyrian/js/src/main/scala/tyrian/runtime/TaskRunner.scala
@@ -15,7 +15,7 @@ object TaskRunner:
   def execTask[Err, Success](task: Task[Err, Success], notifier: Either[Err, Success] => Unit): Unit =
     task match
       case Task.SideEffect(thunk)         => thunk()
-      case Task.Delay(thunk)              => try { Right(thunk()) } catch { case NonFatal(e) => Left(e.getMessage) }
+      case Task.Delay(thunk)              => notifier(try { Right(thunk()) } catch { case NonFatal(e) => Left(e.getMessage) })
       case Task.Succeeded(value)          => notifier(Right(value))
       case Task.Failed(error)             => notifier(Left(error))
       case Task.RunObservable(observable) => observable.run(asObserver(notifier))

--- a/tyrian/js/src/main/scala/tyrian/websocket/WebSocket.scala
+++ b/tyrian/js/src/main/scala/tyrian/websocket/WebSocket.scala
@@ -81,7 +81,7 @@ object WebSocket:
             val msg =
               try { e.asInstanceOf[dom.ErrorEvent].message }
               catch { case _: Throwable => "Unknown" }
-            Some(WebSocketEvent.Error("Web socket connection error"))
+            Some(WebSocketEvent.Error(msg))
           },
           Sub.fromEvent("close", socket) { e =>
             if settings.enabled then keepAlive.cancel() else ()

--- a/tyrian/js/src/main/scala/tyrian/websocket/WebSocket.scala
+++ b/tyrian/js/src/main/scala/tyrian/websocket/WebSocket.scala
@@ -48,27 +48,27 @@ object KeepAliveSettings:
 
 object WebSocket:
   /** Acquires a WebSocket connection with default keep-alive message */
-  def connect(address: String): Either[String, WebSocket] =
+  def connect(address: String): Task[String, WebSocket] =
     newConnection(address, None, KeepAliveSettings.default).map(WebSocket(_))
 
   /** Acquires a WebSocket connection with default keep-alive message and a custom message onOpen */
-  def connect(address: String, onOpenMessage: String): Either[String, WebSocket] =
+  def connect(address: String, onOpenMessage: String): Task[String, WebSocket] =
     newConnection(address, Option(onOpenMessage), KeepAliveSettings.default).map(WebSocket(_))
 
   /** Acquires a WebSocket connection with custom keep-alive message */
-  def connect(address: String, keepAliveSettings: KeepAliveSettings): Either[String, WebSocket] =
+  def connect(address: String, keepAliveSettings: KeepAliveSettings): Task[String, WebSocket] =
     newConnection(address, None, keepAliveSettings).map(WebSocket(_))
 
   /** Acquires a WebSocket connection with a custom keep-alive message and a custom message onOpen */
-  def connect(address: String, onOpenMessage: String, keepAliveSettings: KeepAliveSettings): Either[String, WebSocket] =
+  def connect(address: String, onOpenMessage: String, keepAliveSettings: KeepAliveSettings): Task[String, WebSocket] =
     newConnection(address, Some(onOpenMessage), keepAliveSettings).map(WebSocket(_))
 
   private def newConnection(
       address: String,
       onOpenSendMessage: Option[String],
       settings: KeepAliveSettings
-  ): Either[String, LiveSocket] =
-    try {
+  ): Task[String, LiveSocket] =
+    Task.Delay { () =>
       val socket    = new dom.WebSocket(address)
       val keepAlive = new KeepAlive(socket, settings.message, settings.timeout)
 
@@ -95,10 +95,7 @@ object WebSocket:
           }
         )
 
-      Right(LiveSocket(socket, subs))
-    } catch {
-      case e: Throwable =>
-        Left(s"Error trying to set up websocket: ${e.getMessage}")
+      LiveSocket(socket, subs)
     }
 
   final class KeepAlive(socket: dom.WebSocket, msg: String, timeout: FiniteDuration):

--- a/tyrian/js/src/main/scala/tyrian/websocket/WebSocketEvent.scala
+++ b/tyrian/js/src/main/scala/tyrian/websocket/WebSocketEvent.scala
@@ -1,7 +1,7 @@
 package tyrian.websocket
 
 enum WebSocketEvent derives CanEqual:
-  case Open                     extends WebSocketEvent
-  case Receive(message: String) extends WebSocketEvent
-  case Error(error: String)     extends WebSocketEvent
-  case Close                    extends WebSocketEvent
+  case Open
+  case Receive(message: String)
+  case Error(error: String)
+  case Close(code: Int, reason: String)


### PR DESCRIPTION
closes #52 

Besides adding a keep-alive connection mechanism, I made a change so the WebSocket connection has to be initiated explicitly. The side-effect of creating the connection was previously performed when invoking the `subscribe` method. Now there is no way to call `subscribe` without having a WS connection, which can be done via any of the `WebSocket.connect` variants.

The side-effect is still there but now the name `connect` tells you that is going to happen. I don't know if there's a mechanism in Tyrian where this can be managed by a `Task` like `Cmd` or `Sub`, so for now I live it as is and return `Either[String, WebSocket]`.

I wrote the initial implementation in JavaScript: https://github.com/gvolpe/trading/blob/main/web-app/js/WsPorts.js

There are still a few other things that can be improved in this Scala version. ~~For example, when the user closes the browser tab, that is properly handled in the JS version. I need to play around a bit more and see if the Scala version behaves as expected.~~ UPDATE: it works. I added a few improvements in the second commit. 

~~Also, the keep-alive timeout could probably be made configurable as well but I think this is a good first step.~~ UPDATE 2: Added a `KeepAliveSettings` to configure the timeout and a few other things; it simplified things :)

Let me know what you think, and thanks a lot for working on Tyrian! Really good first experience in ScalaJS for me :)