### PR TITLE
Fixed #54: 'No value' attributes with predicate

### DIFF
--- a/indigo-sandbox/src/main/scala/example/IndigoSandbox.scala
+++ b/indigo-sandbox/src/main/scala/example/IndigoSandbox.scala
@@ -88,7 +88,7 @@ object IndigoSandbox extends TyrianApp[Msg, Model]:
     ) ++ counters
 
     div(
-      div("Random number: " + model.randomNumber.toString),
+      div(hidden(false))("Random number: " + model.randomNumber.toString),
       div(id := gameDivId1)(),
       div(id := gameDivId2)(),
       div(

--- a/project/AttributeGen.scala
+++ b/project/AttributeGen.scala
@@ -45,7 +45,8 @@ object AttributeGen {
 
   def genNoValue(attrName: String, realName: Option[String]): String = {
     val attr = realName.getOrElse(attrName.toLowerCase)
-    s"""  def $attrName: Attr[Nothing] = Attribute("$attr", "$attr")
+    s"""  def $attrName: NamedAttribute = NamedAttribute("$attr")
+    |  def $attrName(isUsed: Boolean): Attr[Nothing] = if isUsed then NamedAttribute("$attr") else EmptyAttribute
     |
     |""".stripMargin
   }

--- a/tyrian/js/src/test/scala/tyrian/AttrTests.scala
+++ b/tyrian/js/src/test/scala/tyrian/AttrTests.scala
@@ -1,0 +1,15 @@
+package tyrian
+
+import org.scalajs.dom.document
+import snabbdom.VNode
+import tyrian.Html.*
+import tyrian.runtime.TyrianRuntime
+
+class AttrTests extends munit.FunSuite {
+
+  test("hidden can be made standalone") {
+    val attr = hidden
+    assert(clue(attr.name) == "hidden")
+  }
+
+}

--- a/tyrian/shared/src/main/scala/tyrian/Attr.scala
+++ b/tyrian/shared/src/main/scala/tyrian/Attr.scala
@@ -4,6 +4,16 @@ package tyrian
 sealed trait Attr[+M]:
   def map[N](f: M => N): Attr[N]
 
+/** An attribute of an HTML tag that is does not exist, used as a "do not render" placeholder
+  */
+case object EmptyAttribute extends Attr[Nothing]:
+  def map[N](f: Nothing => N): EmptyAttribute.type = this
+
+/** An attribute of an HTML tag that only has a name, no value
+  */
+final case class NamedAttribute(name: String) extends Attr[Nothing]:
+  def map[N](f: Nothing => N): NamedAttribute = this
+
 /** Attribute of an HTML tag
   *
   * Attributes are like properties, but can be removed. This is important for attributes like disabled, hidden, selected

--- a/tyrian/shared/src/main/scala/tyrian/Attr.scala
+++ b/tyrian/shared/src/main/scala/tyrian/Attr.scala
@@ -4,7 +4,7 @@ package tyrian
 sealed trait Attr[+M]:
   def map[N](f: M => N): Attr[N]
 
-/** An attribute of an HTML tag that is does not exist, used as a "do not render" placeholder
+/** An attribute of an HTML tag that does not exist, used as a "do not render" placeholder
   */
 case object EmptyAttribute extends Attr[Nothing]:
   def map[N](f: Nothing => N): EmptyAttribute.type = this

--- a/tyrian/shared/src/main/scala/tyrian/runtime/TyrianSSR.scala
+++ b/tyrian/shared/src/main/scala/tyrian/runtime/TyrianSSR.scala
@@ -1,6 +1,6 @@
 package tyrian.runtime
 
-import tyrian._
+import tyrian.*
 
 object TyrianSSR:
 
@@ -42,7 +42,7 @@ object Render:
       html match
         case tag: Tag[_] =>
           val attributes =
-            spacer(tag.attributes.map(_.render).mkString(" "))
+            spacer(tag.attributes.map(_.render).filterNot(_.isEmpty).mkString(" "))
 
           val children = tag.children.map {
             case t: Text    => t.value
@@ -54,9 +54,11 @@ object Render:
   extension (a: Attr[_])
     def render: String =
       a match
-        case _: Event[_, _] => ""
-        case a: Attribute   => a.render
-        case p: Property    => p.render
+        case _: Event[_, _]         => ""
+        case a: Attribute           => a.render
+        case p: Property            => p.render
+        case a: NamedAttribute      => a.name
+        case _: EmptyAttribute.type => ""
 
   extension (a: Attribute)
     def render: String =

--- a/tyrian/shared/src/test/scala/tyrian/runtime/TyrianSSRTests.scala
+++ b/tyrian/shared/src/test/scala/tyrian/runtime/TyrianSSRTests.scala
@@ -70,6 +70,36 @@ class TyrianSSRTests extends munit.FunSuite {
     assertEquals(actual, expected)
   }
 
+  test("Can render attributes") {
+    val elems: List[Elem[Msg]] =
+      List(
+        div(id := "my-div", hidden)(("some content"))
+      )
+
+    val actual =
+      TyrianSSR.render(elems)
+
+    val expected =
+      """<div id="my-div" hidden>some content</div>"""
+
+    assertEquals(actual, expected)
+  }
+
+  test("Can render attributes and exclude hidden ones") {
+    val elems: List[Elem[Msg]] =
+      List(
+        div(id := "my-div", hidden(false))(("some content"))
+      )
+
+    val actual =
+      TyrianSSR.render(elems)
+
+    val expected =
+      """<div id="my-div">some content</div>"""
+
+    assertEquals(actual, expected)
+  }
+
   test("Can render a simple page") {
     val elems: Elem[Msg] =
       html(


### PR DESCRIPTION
(cc @gvolpe)

This PR allows you to:

1. Set no-value attributes based on a predicate, i.e. `hidden(true)` (hides the element, false removes the attribute showing the element)
2. Use `EmptyAttribute` or `NamedAttribute` if you wish, on top of the normal `Attribute`, `Property` and `Event` `Attr` types.

This is insanely hard to test, I did try. I have added tests for the SSR version but I ended up manually testing the dom version. Need to work out some sort of dom based testing with snabbdom. There is a ticket open for this.