### PR TITLE
Fixed #56: Create a "focus" Cmd

### DIFF
--- a/sandbox/src/main/scala/example/Sandbox.scala
+++ b/sandbox/src/main/scala/example/Sandbox.scala
@@ -2,6 +2,7 @@ package example
 
 import tyrian.Html.*
 import tyrian.*
+import tyrian.cmds.Dom
 import tyrian.cmds.Logger
 import tyrian.websocket.*
 
@@ -15,6 +16,16 @@ object Sandbox extends TyrianApp[Msg, Model]:
 
   def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
     msg match
+      case Msg.Log(msg) =>
+        (model, Logger.info(msg))
+
+      case Msg.FocusOnInputField =>
+        val cmd = Dom.focus("text-reverse-field") {
+          case Left(Dom.NotFound(id)) => Msg.Log("Element not found: " + id)
+          case _                      => Msg.Log("Focused on input field")
+        }
+        (model, cmd)
+
       case Msg.NewContent(content) =>
         (model.copy(field = content), Cmd.Empty)
 
@@ -55,7 +66,8 @@ object Sandbox extends TyrianApp[Msg, Model]:
 
     div(
       div(
-        input(placeholder := "Text to reverse", onInput(s => Msg.NewContent(s)), myStyle),
+        button(onClick(Msg.FocusOnInputField))("Focus on the textfield"),
+        input(id := "text-reverse-field", placeholder := "Text to reverse", onInput(s => Msg.NewContent(s)), myStyle),
         div(myStyle)(text(model.field.reverse))
       ),
       div(elems),
@@ -91,12 +103,14 @@ object Sandbox extends TyrianApp[Msg, Model]:
     }
 
 enum Msg:
-  case NewContent(content: String)      extends Msg
-  case Insert                           extends Msg
-  case Remove                           extends Msg
-  case Modify(i: Int, msg: Counter.Msg) extends Msg
-  case FromSocket(message: String)      extends Msg
-  case ToSocket(message: String)        extends Msg
+  case NewContent(content: String)
+  case Insert
+  case Remove
+  case Modify(i: Int, msg: Counter.Msg)
+  case FromSocket(message: String)
+  case ToSocket(message: String)
+  case FocusOnInputField
+  case Log(msg: String)
 
 object Counter:
 

--- a/tyrian/js/src/main/scala/tyrian/cmds/Dom.scala
+++ b/tyrian/js/src/main/scala/tyrian/cmds/Dom.scala
@@ -1,0 +1,32 @@
+package tyrian.cmds
+
+import org.scalajs.dom.document
+import org.scalajs.dom.raw.HTMLInputElement
+import tyrian.Cmd
+
+object Dom:
+
+  final case class NotFound(elementId: String)
+
+  def focus[Msg](elementId: String)(resultToMessage: Either[NotFound, Unit] => Msg): Cmd[Msg] =
+    affectInputElement(elementId, _.focus(), resultToMessage)
+
+  def blur[Msg](elementId: String)(resultToMessage: Either[NotFound, Unit] => Msg): Cmd[Msg] =
+    affectInputElement(elementId, _.blur(), resultToMessage)
+
+  @SuppressWarnings(Array("scalafix:DisableSyntax.null"))
+  private def affectInputElement[Msg](
+      elementId: String,
+      modifier: HTMLInputElement => Unit,
+      resultToMessage: Either[NotFound, Unit] => Msg
+  ): Cmd[Msg] =
+    Cmd
+      .Run[NotFound, Unit] { observer =>
+        val node = document.getElementById(elementId)
+
+        if node != null then observer.onNext(modifier(node.asInstanceOf[HTMLInputElement]))
+        else observer.onError(NotFound(elementId))
+
+        () => ()
+      }
+      .attempt(resultToMessage)


### PR DESCRIPTION
(cc @gvolpe)

This PR gives you commands to focus and blur (un-focus?) HTMLInputElements.

They are based on the commands in the Elm [Browser.Dom](https://package.elm-lang.org/packages/elm/browser/latest/Browser.Dom) package.

I have an open question about this implementation: Currently it insists that you deal with the possible error (i.e. element not found) and even the success of running the side effect by producing more messages. This might be desirable, but I wonder if it would be good to somehow have a fire and forget version, and maybe a version that only emits an event on error (if it's even possible to build such things)? I'll sleep on it.