### PR TITLE
docs: remove main module initializer option

### DIFF
--- a/docs/installation/_index.md
+++ b/docs/installation/_index.md
@@ -45,7 +45,6 @@ libraryDependencies ++= Seq(
   "io.indigoengine" %%% "tyrian" % "@VERSION@"
 )
 
-scalaJSUseMainModuleInitializer := true,
 scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
 ```
 


### PR DESCRIPTION
It seems no longer necessary and the examples don't compile with this option, so removing it from the docs.