### PR TITLE
WebSocket: keep-alive mechanism as a Sub

### DIFF
--- a/tyrian/js/src/main/scala/tyrian/websocket/WebSocketEvent.scala
+++ b/tyrian/js/src/main/scala/tyrian/websocket/WebSocketEvent.scala
@@ -5,3 +5,4 @@ enum WebSocketEvent derives CanEqual:
   case Receive(message: String)
   case Error(error: String)
   case Close(code: Int, reason: String)
+  case Heartbeat


### PR DESCRIPTION
closes #67 

Not sure if this is what you had in mind, but I went for it anyway 😄 In addition, I added a graceful shutdown example. 

👍🏽 re-using the `Sub.every` mechanism.
🤔 the heartbeat message needs to be sent by the user.

I think it would be great if we could re-use `Sub.every` but the heartbeat message was sent internally, as this is client-server communication that has nothing to do with user messages.

I'd love to hear what you think! 😃 