### PR TITLE
nix: add correct mill overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
         let
           pkgs = import nixpkgs {
             inherit system;
-            overlays = [ (f: p: { jre8 = p.jdk17_headless; }) ];
+            overlays = [ (f: p: { mill = p.mill.override { jre = p.jdk17_headless; }; }) ];
           };
           jdk = pkgs.jdk17_headless;
 


### PR DESCRIPTION
Tiny change that overrides the `jre` version used by `mill` in the right way.