### PR TITLE
Fix Body constructors

### DIFF
--- a/tyrian/js/src/main/scala/tyrian/http/Models.scala
+++ b/tyrian/js/src/main/scala/tyrian/http/Models.scala
@@ -41,6 +41,7 @@ enum Body derives CanEqual:
     */
   case PlainText(contentType: String, body: String) extends Body
 
+object Body:
   def html(body: String): Body = Body.PlainText("text/html", body)
   def json(body: String): Body = Body.PlainText("application/json", body)
   def xml(body: String): Body  = Body.PlainText("application/xml", body)


### PR DESCRIPTION
Presumably it should be working as:

```scala
Body.json("{}")
```

whereas currently it works only as:

```scala
Body.Empty.json("{}")
```

No tests seem to be affected.