### PR TITLE
Need for accurate speed

### DIFF
--- a/tyrian/js/src/main/scala/tyrian/Tyrian.scala
+++ b/tyrian/js/src/main/scala/tyrian/Tyrian.scala
@@ -57,7 +57,7 @@ object Tyrian:
 
         runtime <- Async[F].delay {
           new TyrianRuntime(
-            init,
+            init._2,
             update,
             view,
             subscriptions,

--- a/tyrian/js/src/main/scala/tyrian/Tyrian.scala
+++ b/tyrian/js/src/main/scala/tyrian/Tyrian.scala
@@ -9,6 +9,7 @@ import fs2.Stream
 import fs2.concurrent.Channel
 import org.scalajs.dom.Element
 import snabbdom.VNode
+import tyrian.runtime.ModelHolder
 import tyrian.runtime.TyrianRuntime
 import tyrian.runtime.TyrianSSR
 
@@ -50,7 +51,7 @@ object Tyrian:
     Dispatcher[F].evalMap { dispatcher =>
       for {
         channel <- Channel.synchronous[F, F[Unit]]
-        model   <- Async[F].ref(init._1)
+        model   <- Async[F].ref(ModelHolder[Model](init._1, true))
         vnode   <- Async[F].ref[Option[VNode]](None)
 
         runtime <- Async[F].delay {

--- a/tyrian/js/src/main/scala/tyrian/Tyrian.scala
+++ b/tyrian/js/src/main/scala/tyrian/Tyrian.scala
@@ -47,7 +47,7 @@ object Tyrian:
       update: Model => Msg => (Model, Cmd[F, Msg]),
       view: Model => Html[Msg],
       subscriptions: Model => Sub[F, Msg],
-      maxConcurrentMessages: Int
+      maxConcurrentTasks: Int
   ): Resource[F, TyrianRuntime[F, Model, Msg]] =
     Dispatcher[F].evalMap { dispatcher =>
       for {
@@ -73,7 +73,7 @@ object Tyrian:
 
       } yield Stream
         .emit(runtime)
-        .concurrently(Stream.fromQueueUnterminated(queue).parEvalMap(maxConcurrentMessages)(identity))
+        .concurrently(Stream.fromQueueUnterminated(queue).parEvalMap(maxConcurrentTasks)(identity))
         .compile
         .resource
         .lastOrError

--- a/tyrian/js/src/main/scala/tyrian/Tyrian.scala
+++ b/tyrian/js/src/main/scala/tyrian/Tyrian.scala
@@ -52,16 +52,18 @@ object Tyrian:
     Dispatcher[F].evalMap { dispatcher =>
       for {
         queue <- Queue.unbounded[F, F[Unit]]
-        model <- Async[F].ref(ModelHolder[Model](init._1, true))
-        vnode <- Async[F].ref[Option[VNode]](None)
+
+        (initialModel, initialCmd) = init
+
+        model <- Async[F].ref(ModelHolder[Model](initialModel, true))
+        vnode <- Async[F].ref[Element | VNode](node)
 
         runtime <- Async[F].delay {
           new TyrianRuntime(
-            init._2,
+            initialCmd,
             update,
             view,
             subscriptions,
-            node,
             model,
             vnode,
             queue,

--- a/tyrian/js/src/main/scala/tyrian/TyrianAppF.scala
+++ b/tyrian/js/src/main/scala/tyrian/TyrianAppF.scala
@@ -12,7 +12,10 @@ import scala.scalajs.js.annotation._
   */
 trait TyrianAppF[F[_]: Async, Msg, Model]:
 
-  def MaxConcurrentMessages: Int = 1024
+  /** Specifies the number of queued tasks that can be consumed at any one time. Default is 1024 which is assumed to be
+    * more than sufficient, however the value can be tweaked in your app by overriding this value.
+    */
+  def MaxConcurrentTasks: Int = 1024
 
   val run: Resource[F, TyrianRuntime[F, Model, Msg]] => Unit
 
@@ -62,6 +65,6 @@ trait TyrianAppF[F[_]: Async, Msg, Model]:
         update,
         view,
         subscriptions,
-        MaxConcurrentMessages
+        MaxConcurrentTasks
       )
     )

--- a/tyrian/js/src/main/scala/tyrian/TyrianAppF.scala
+++ b/tyrian/js/src/main/scala/tyrian/TyrianAppF.scala
@@ -12,6 +12,8 @@ import scala.scalajs.js.annotation._
   */
 trait TyrianAppF[F[_]: Async, Msg, Model]:
 
+  def MaxConcurrentMessages: Int = 1024
+
   val run: Resource[F, TyrianRuntime[F, Model, Msg]] => Unit
 
   /** Used to initialise your app. Accepts simple flags and produces the initial model state, along with any commands to
@@ -59,6 +61,7 @@ trait TyrianAppF[F[_]: Async, Msg, Model]:
         init(flags),
         update,
         view,
-        subscriptions
+        subscriptions,
+        MaxConcurrentMessages
       )
     )

--- a/tyrian/js/src/main/scala/tyrian/runtime/ModelHolder.scala
+++ b/tyrian/js/src/main/scala/tyrian/runtime/ModelHolder.scala
@@ -1,0 +1,3 @@
+package tyrian.runtime
+
+final class ModelHolder[Model](val model: Model, val updated: Boolean)

--- a/tyrian/js/src/main/scala/tyrian/runtime/Rendering.scala
+++ b/tyrian/js/src/main/scala/tyrian/runtime/Rendering.scala
@@ -1,0 +1,64 @@
+package tyrian.runtime
+
+import org.scalajs.dom
+import org.scalajs.dom.Element
+import snabbdom._
+import snabbdom.modules._
+import tyrian.Attribute
+import tyrian.Event
+import tyrian.Html
+import tyrian.NamedAttribute
+import tyrian.Property
+import tyrian.Tag
+import tyrian.Text
+
+object Rendering:
+
+  def toVNode[Msg](html: Html[Msg], onMsg: Msg => Unit): VNode =
+    html match
+      case Tag(name, attrs, children) =>
+        val as: List[(String, String)] =
+          attrs.collect {
+            case Attribute(n, v)   => (n, v)
+            case NamedAttribute(n) => (n, "")
+          }
+
+        val props: List[(String, PropValue)] =
+          attrs.collect { case Property(n, v) => (n, v) }
+
+        val events: List[(String, EventHandler)] =
+          attrs.collect { case Event(n, msg) =>
+            (n, EventHandler((e: dom.Event) => onMsg(msg.asInstanceOf[dom.Event => Msg](e))))
+          }
+
+        val data: VNodeData =
+          VNodeData.empty.copy(
+            props = props.toMap,
+            attrs = as.toMap,
+            on = events.toMap
+          )
+
+        val childrenElem: Array[VNode] =
+          children.toArray.map {
+            case t: Text            => VNode.text(t.value)
+            case subHtml: Html[Msg] => toVNode(subHtml, onMsg)
+          }
+
+        h(name, data, childrenElem)
+
+  private lazy val patch: Patch =
+    snabbdom.init(
+      Seq(
+        Attributes.module,
+        Classes.module,
+        Props.module,
+        Styles.module,
+        EventListeners.module,
+        Dataset.module
+      )
+    )
+
+  def render[Model, Msg](oldNode: Element | VNode, model: Model, view: Model => Html[Msg], onMsg: Msg => Unit): VNode =
+    oldNode match
+      case em: Element => patch(em, Rendering.toVNode(view(model), onMsg))
+      case vn: VNode   => patch(vn, Rendering.toVNode(view(model), onMsg))

--- a/tyrian/js/src/main/scala/tyrian/runtime/TyrianRuntime.scala
+++ b/tyrian/js/src/main/scala/tyrian/runtime/TyrianRuntime.scala
@@ -8,31 +8,21 @@ import cats.syntax.all.*
 import fs2.Stream
 import org.scalajs.dom
 import org.scalajs.dom.Element
-import snabbdom._
-import snabbdom.modules._
+import snabbdom.VNode
 import tyrian.Attr
 import tyrian.Attribute
 import tyrian.Cmd
 import tyrian.Event
 import tyrian.Html
-import tyrian.NamedAttribute
-import tyrian.Property
 import tyrian.Sub
-import tyrian.Tag
-import tyrian.Text
-import util.Functions.fun
-
-import scala.scalajs.js
-import scala.scalajs.js.Dynamic.{literal => obj}
 
 final class TyrianRuntime[F[_]: Async, Model, Msg](
     initCmd: Cmd[F, Msg],
     update: Model => Msg => (Model, Cmd[F, Msg]),
     view: Model => Html[Msg],
     subscriptions: Model => Sub[F, Msg],
-    node: Element,
     model: Ref[F, ModelHolder[Model]],
-    vnode: Ref[F, Option[VNode]],
+    vnode: Ref[F, Element | VNode],
     queue: => Queue[F, F[Unit]],
     dispatcher: => Dispatcher[F]
 ):
@@ -53,23 +43,17 @@ final class TyrianRuntime[F[_]: Async, Model, Msg](
       for {
         currentModel <- model.get
         (updatedState, cmd) = update(currentModel.model)(msg)
-        complete <- completeUpdate(cmd, updatedState)
-      } yield complete
+        _ <- completeUpdate(cmd, updatedState)
+      } yield ()
 
     dispatcher.unsafeRunAndForget(res)
 
   private def completeUpdate(cmd: Cmd[F, Msg], updatedState: Model): F[Unit] =
-    val results: F[Stream[F, F[Unit]]] =
-      for {
-        _           <- model.set(ModelHolder(updatedState, true))
-        sideEffects <- gatherSideEffects(cmd, subscriptions(updatedState))
-      } yield Stream.emits(sideEffects)
-
-    Async[F].flatMap(results) { (stream: Stream[F, F[Unit]]) =>
-      stream.foreach(queue.offer).compile.drain
-    }
-
-  private given CanEqual[Option[_], Option[_]] = CanEqual.derived
+    for {
+      _           <- model.set(ModelHolder(updatedState, true))
+      sideEffects <- gatherSideEffects(cmd, subscriptions(updatedState))
+      _           <- Stream.emits(sideEffects).foreach(queue.offer).compile.drain
+    } yield ()
 
   private def gatherSideEffects(
       cmd: Cmd[F, Msg],
@@ -123,83 +107,28 @@ final class TyrianRuntime[F[_]: Async, Model, Msg](
 
   // Render
 
-  private def toVNode(html: Html[Msg]): VNode =
-    html match
-      case Tag(name, attrs, children) =>
-        val as: List[(String, String)] =
-          attrs.collect {
-            case Attribute(n, v)   => (n, v)
-            case NamedAttribute(n) => (n, "")
-          }
-
-        val props: List[(String, PropValue)] =
-          attrs.collect { case Property(n, v) => (n, v) }
-
-        val events: List[(String, EventHandler)] =
-          attrs.collect { case Event(n, msg) =>
-            (n, EventHandler((e: dom.Event) => onMsg(msg.asInstanceOf[dom.Event => Msg](e))))
-          }
-
-        val data: VNodeData =
-          VNodeData.empty.copy(
-            props = props.toMap,
-            attrs = as.toMap,
-            on = events.toMap
-          )
-
-        val childrenElem: Array[VNode] =
-          children.toArray.map {
-            case t: Text            => VNode.text(t.value)
-            case subHtml: Html[Msg] => toVNode(subHtml)
-          }
-
-        h(name, data, childrenElem)
-
-  private lazy val patch: Patch =
-    snabbdom.init(
-      Seq(
-        Attributes.module,
-        Classes.module,
-        Props.module,
-        Styles.module,
-        EventListeners.module,
-        Dataset.module
-      )
-    )
-
-  private def render(oldNode: Element | VNode, model: Model): VNode =
-    oldNode match
-      case em: Element => patch(em, toVNode(view(model)))
-      case vn: VNode   => patch(vn, toVNode(view(model)))
-
-  private def renderLoop(time: Double): Unit =
-    def res: F[Unit] =
+  private def renderLoop(): Unit =
+    def redraw: F[Unit] =
       Async[F].flatMap(model.get) { m =>
         if m.updated then
           for {
-            n <- vnode.get
-            _ <- vnode.set(n match {
-              case Some(existingNode) => Some(render(existingNode, m.model))
-              case None               => Some(render(node, m.model))
-            })
+            _ <- vnode.updateAndGet(n => Rendering.render(n, m.model, view, onMsg))
             _ <- model.set(ModelHolder(m.model, false))
           } yield ()
         else Async[F].unit
       }
 
-    dom.window.requestAnimationFrame { t =>
-      dispatcher.unsafeRunAndForget(res)
-      renderLoop(t)
+    dom.window.requestAnimationFrame { _ =>
+      dispatcher.unsafeRunAndForget(redraw)
+      renderLoop()
     }
 
   // Start up
 
   def start(): Unit =
-    renderLoop(0)
+    renderLoop()
     dispatcher.unsafeRunAndForget(
       model.get.flatMap { m =>
         completeUpdate(initCmd, m.model)
       }
     )
-
-final class ModelHolder[Model](val model: Model, val updated: Boolean)


### PR DESCRIPTION
This PR revisits the runtime implementation to do four things:

1. Decrease time to first page draw
2. Run `Cmd`s in parallel
3. Evaluate tasks in the order sent
4. Split update from render