### PR TITLE
Fixed #143: Extension syntax to make Cmds/Subs

### DIFF
--- a/tyrian/js/src/main/scala/tyrian/syntax.scala
+++ b/tyrian/js/src/main/scala/tyrian/syntax.scala
@@ -12,7 +12,7 @@ object syntax:
 
   /** Make a cmd from any `F[A]`
     */
-  extension [F[_], A, Msg](task: F[A])
+  extension [F[_], A](task: F[A])
     def toCmd: Cmd.Run[F, A, A] =
       Cmd.Run(task)(identity)
 

--- a/tyrian/js/src/main/scala/tyrian/syntax.scala
+++ b/tyrian/js/src/main/scala/tyrian/syntax.scala
@@ -1,0 +1,23 @@
+package tyrian
+
+import cats.effect.Async
+
+object syntax:
+
+  /** Make a side effect cmd from any `F[Unit]`
+    */
+  extension [F[_]](task: F[Unit])
+    def toCmd: Cmd.SideEffect[F] =
+      Cmd.SideEffect(task)
+
+  /** Make a cmd from any `F[A]`
+    */
+  extension [F[_], A, Msg](task: F[A])
+    def toCmd: Cmd.Run[F, A, A] =
+      Cmd.Run(task)(identity)
+
+  /** Make a sub from an `fs2.Stream`
+    */
+  extension [F[_]: Async, A](stream: fs2.Stream[F, A])
+    def toSub(id: String): Sub[F, A] =
+      Sub.make(id, stream)


### PR DESCRIPTION
Basically for certain types of value you to create a `Cmd` or `Sub` by adding `toCmd` or `toSub` to the end.

It isn't complicated, but it's kinda fun because you can just for-comp a nice task based process together and then say `myFunkyIOThing.toCmd` at the end.

Added examples to the Sandbox just to prove to myself they worked.

More advanced extension methods get complicated quickly so I'm stopping here. I tried to do versions that would convert lists to `Cmd`s to a `Cmd.Batch` but the type inference fell to pieces. Creating `Sub`s is also not straight-forward in general, in fact the `fs2.Stream` version we have here is by far the simplest approach. After that you're better off with one of the existing `Sub` constructors so that you get some clue that you need to manufacture a callback.