### PR TITLE
Remove use of NonFatal exception

### DIFF
--- a/sandbox/src/main/scala/example/Sandbox.scala
+++ b/sandbox/src/main/scala/example/Sandbox.scala
@@ -515,7 +515,7 @@ object Page:
       case "page5"  => Page5
       case "#page6" => Page6
       case "page6"  => Page6
-      case s        => Page1
+      case _        => Page1
 
 object Model:
   // val echoServer = "ws://ws.ifelse.io" // public echo server

--- a/tyrian/js/src/main/scala/tyrian/HotReload.scala
+++ b/tyrian/js/src/main/scala/tyrian/HotReload.scala
@@ -6,7 +6,6 @@ import util.Functions
 
 import scala.concurrent.duration.FiniteDuration
 import scala.scalajs.js
-import scala.util.control.NonFatal
 
 /** A very simple mechanism to allow automatic loading and saving of your applications model to local storage. Uses:
   *

--- a/tyrian/js/src/main/scala/tyrian/Navigation.scala
+++ b/tyrian/js/src/main/scala/tyrian/Navigation.scala
@@ -6,7 +6,6 @@ import org.scalajs.dom.window
 import tyrian.Sub
 
 import scala.scalajs.js
-import scala.util.control.NonFatal
 
 /** Provides simple routing based on url hash (anchor), such as: `http://mysite.com/#page1` */
 object Navigation:
@@ -26,7 +25,7 @@ object Navigation:
         Option[Result.HashChange](Result.HashChange(evt.oldURL, oldFrag, evt.newURL, newFrag))
           .map(resultToMessage)
       } catch {
-        case NonFatal(e) =>
+        case _ =>
           None
       }
     }

--- a/tyrian/js/src/main/scala/tyrian/cmds/LocalStorage.scala
+++ b/tyrian/js/src/main/scala/tyrian/cmds/LocalStorage.scala
@@ -6,7 +6,6 @@ import org.scalajs.dom
 import tyrian.Cmd
 
 import scala.annotation.targetName
-import scala.util.control.NonFatal
 
 object LocalStorage:
 


### PR DESCRIPTION
Noticed while investigating issues with Subs.

Adding `NonFatal` as the catch condition on the Navigation Sub was well intentioned, but the result is that we're leaking Java style errors in a JavaScript environment, which was the intended behaviour. In this case we're doing an `indexOf` inside a `try` block with the full expectation of it being caught, but it isn't. JS throws the exception and carries on regardless.. so what's the point of the exception or the try?