### PR TITLE
Add tags with raw HTML

### DIFF
--- a/tyrian/js/src/main/scala/tyrian/runtime/Rendering.scala
+++ b/tyrian/js/src/main/scala/tyrian/runtime/Rendering.scala
@@ -39,9 +39,13 @@ object Rendering:
 
   def toVNode[Msg](html: Html[Msg], onMsg: Msg => Unit): VNode =
     html match
-      case RawTag(name, attrs, innerHTML) =>
+      case RawTag(name, attrs, html) =>
         val data = buildNodeData(attrs, onMsg)
-        h(name, data, innerHTML)
+        val elm  = dom.document.createElement(name)
+        elm.innerHTML = html
+        val vNode = snabbdom.toVNode(elm)
+        vNode.data = data
+        vNode
 
       case Tag(name, attrs, children) =>
         val data = buildNodeData(attrs, onMsg)

--- a/tyrian/shared/src/main/scala/tyrian/Html.scala
+++ b/tyrian/shared/src/main/scala/tyrian/Html.scala
@@ -10,10 +10,6 @@ sealed trait Elem[+M]:
 final case class Text(value: String) extends Elem[Nothing]:
   def map[N](f: Nothing => N): Text = this
 
-// TODO remove
-// final case class Raw(html: String) extends Elem[Nothing]:
-//   def map[N](f: Nothing => N): Raw = this
-
 /** Base class for HTML tags */
 sealed trait Html[+M] extends Elem[M]:
   def map[N](f: M => N): Html[N]

--- a/tyrian/shared/src/main/scala/tyrian/Html.scala
+++ b/tyrian/shared/src/main/scala/tyrian/Html.scala
@@ -10,6 +10,10 @@ sealed trait Elem[+M]:
 final case class Text(value: String) extends Elem[Nothing]:
   def map[N](f: Nothing => N): Text = this
 
+// TODO remove
+// final case class Raw(html: String) extends Elem[Nothing]:
+//   def map[N](f: Nothing => N): Raw = this
+
 /** Base class for HTML tags */
 sealed trait Html[+M] extends Elem[M]:
   def map[N](f: M => N): Html[N]
@@ -77,3 +81,10 @@ object Aria extends AriaAttributes
 final case class Tag[+M](name: String, attributes: List[Attr[M]], children: List[Elem[M]]) extends Html[M]:
   def map[N](f: M => N): Tag[N] =
     Tag(name, attributes.map(_.map(f)), children.map(_.map(f)))
+
+/** An HTML tag with raw HTML rendered inside. Beware that the inner HTML is not validated to be correct, nor does it
+  * get modified as a response to messages in any way.
+  */
+final case class RawTag[+M](name: String, attributes: List[Attr[M]], innerHTML: String) extends Html[M]:
+  def map[N](f: M => N): RawTag[N] =
+    RawTag(name, attributes.map(_.map(f)), innerHTML)

--- a/tyrian/shared/src/main/scala/tyrian/Html.scala
+++ b/tyrian/shared/src/main/scala/tyrian/Html.scala
@@ -30,6 +30,12 @@ object Html extends HtmlTags with HtmlAttributes:
   def tag[M](name: String)(attributes: List[Attr[M]])(children: List[Elem[M]]): Html[M] =
     Tag(name, attributes, children)
 
+  def raw[M](name: String)(attributes: Attr[M]*)(html: String): Html[M] =
+    RawTag(name, attributes.toList, html)
+  @targetName("raw-list")
+  def raw[M](name: String)(attributes: List[Attr[M]])(html: String): Html[M] =
+    RawTag(name, attributes, html)
+
   // Custom tag syntax
 
   def radio[M](name: String, checked: Boolean, attributes: Attr[M]*): Html[M] =

--- a/tyrian/shared/src/main/scala/tyrian/runtime/TyrianSSR.scala
+++ b/tyrian/shared/src/main/scala/tyrian/runtime/TyrianSSR.scala
@@ -40,6 +40,10 @@ object Render:
   extension [Msg](html: Html[Msg])
     def render: String =
       html match
+        case tag: RawTag[_] =>
+          val attributes =
+            spacer(tag.attributes.map(_.render).filterNot(_.isEmpty).mkString(" "))
+          s"""<${tag.name}$attributes>${tag.innerHTML}</${tag.name}>"""
         case tag: Tag[_] =>
           val attributes =
             spacer(tag.attributes.map(_.render).filterNot(_.isEmpty).mkString(" "))


### PR DESCRIPTION
This PR adds virtual DOM tags that can render arbitrary HTML inside.

Useful for rendering dynamic HTML content that comes outside the Tyrian application, e.g. backend returns meaningful content like Markdown, which then needs to be turned to HTML.

cc @armanbilge @davesmith00000 