### PR TITLE
Improved Mouse & Keyboard events

### DIFF
--- a/sandbox/src/main/scala/example/Sandbox.scala
+++ b/sandbox/src/main/scala/example/Sandbox.scala
@@ -45,6 +45,9 @@ object Sandbox extends TyrianApp[Msg, Model]:
     (Model.init, cmds)
 
   def update(model: Model): Msg => (Model, Cmd[IO, Msg]) =
+    case Msg.MouseMove(to) =>
+      (model.copy(mousePosition = to), Cmd.None)
+
     case Msg.UpdateHttpDetails(newUrl) =>
       (model.copy(http = model.http.copy(url = Option(newUrl))), Cmd.None)
 
@@ -231,7 +234,8 @@ object Sandbox extends TyrianApp[Msg, Model]:
     val contents =
       model.page match
         case Page.Page1 =>
-          div(
+          div(onMouseMove(evt => Msg.MouseMove((evt.screenX.toInt, evt.screenY.toInt))))(
+            raw("div")()(s"<p><i>Mouse Coords ${model.mousePosition}</i></p>"),
             input(
               placeholder := "What should we save?",
               value       := model.tmpSaveData,
@@ -431,6 +435,7 @@ enum Msg:
   case GotHttpError(message: String)
   case UpdateHttpDetails(newUrl: String)
   case FrameTick(runningTime: Double)
+  case MouseMove(to: (Int, Int))
 
 enum Status:
   case Connecting
@@ -474,7 +479,8 @@ final case class Model(
     saveData: Option[String],
     currentTime: js.Date,
     http: HttpDetails,
-    time: Time
+    time: Time,
+    mousePosition: (Int, Int)
 )
 
 final case class Time(running: Double, delta: Double):
@@ -534,7 +540,8 @@ object Model:
       None,
       new js.Date(),
       HttpDetails.initial,
-      Time(0.0d, 0.0d)
+      Time(0.0d, 0.0d),
+      (0, 0)
     )
 
   // We're only saving/loading the input field contents as an example

--- a/tyrian/js/src/main/scala/tyrian/Tyrian.scala
+++ b/tyrian/js/src/main/scala/tyrian/Tyrian.scala
@@ -17,6 +17,7 @@ object Tyrian:
 
   type Event            = org.scalajs.dom.Event
   type KeyboardEvent    = org.scalajs.dom.KeyboardEvent
+  type MouseEvent       = org.scalajs.dom.MouseEvent
   type HTMLInputElement = org.scalajs.dom.HTMLInputElement
 
   /** Directly starts the app. Computes the initial state of the given application, renders it on the given DOM element,

--- a/tyrian/jvm/src/main/scala/tyrian/Tyrian.scala
+++ b/tyrian/jvm/src/main/scala/tyrian/Tyrian.scala
@@ -6,8 +6,9 @@ object Tyrian:
 
   final case class FakeEvent(name: String, value: Any, target: Any)
   final case class FakeHTMLInputElement(value: String)
-  type Event = FakeEvent
-  type KeyboardEvent = FakeEvent
+  type Event            = FakeEvent
+  type KeyboardEvent    = FakeEvent
+  type MouseEvent       = FakeEvent
   type HTMLInputElement = FakeHTMLInputElement
 
   /** Takes a normal Tyrian Model and view function and renders the html to a string prefixed with the doctype.

--- a/tyrian/shared/src/main/scala/tyrian/Html.scala
+++ b/tyrian/shared/src/main/scala/tyrian/Html.scala
@@ -56,8 +56,6 @@ object Html extends HtmlTags with HtmlAttributes:
 
   def dataAttr(name: String, value: String): Attr[Nothing] = Attribute("data-" + name, value)
 
-  def onKeyDown[M](msg: Tyrian.KeyboardEvent => M): Attr[M] = onEvent("keydown", msg)
-  def onKeyUp[M](msg: Tyrian.KeyboardEvent => M): Attr[M]   = onEvent("keyup", msg)
   def onInput[M](msg: String => M): Attr[M] =
     onEvent("input", (e: Tyrian.Event) => msg(e.target.asInstanceOf[Tyrian.HTMLInputElement].value))
 


### PR DESCRIPTION
Just creating this for posterity.

I went in to fix [a typo](https://github.com/PurpleKingdomGames/tyrian/issues/153) that @rlavolee noticed, and in testing it realised there was a bigger improvement to make.

Long story short: You can now do the usual:

```scala
div(onMouseDown(Msg.MouseIsDown))(...)
```
or
```scala
div(onMouseMove(evt => Msg.MouseMove((evt.screenX, evt.screenY))))(...)
```

And this works for `onKeyUp`, `onKeyDown`, `onKeyPress`, `onMouseDown`, `onMouseMove`, `onMouseOut`, `onMouseOver`, `onMouseUp`, `onMouseWheel`.

Oh and yes. I fixed the typo too.
