### PR TITLE
Fixed #159: Adds support for innerHtml syntax

### DIFF
--- a/sandbox/src/main/scala/example/Sandbox.scala
+++ b/sandbox/src/main/scala/example/Sandbox.scala
@@ -235,7 +235,7 @@ object Sandbox extends TyrianApp[Msg, Model]:
       model.page match
         case Page.Page1 =>
           div(onMouseMove(evt => Msg.MouseMove((evt.screenX.toInt, evt.screenY.toInt))))(
-            raw("div")()(s"<p><i>Mouse Coords ${model.mousePosition}</i></p>"),
+            div(id := "mousepos")().innerHtml(s"<p><i>Mouse Coords ${model.mousePosition}</i></p>"),
             input(
               placeholder := "What should we save?",
               value       := model.tmpSaveData,

--- a/tyrian/shared/src/main/scala/tyrian/Html.scala
+++ b/tyrian/shared/src/main/scala/tyrian/Html.scala
@@ -13,6 +13,7 @@ final case class Text(value: String) extends Elem[Nothing]:
 /** Base class for HTML tags */
 sealed trait Html[+M] extends Elem[M]:
   def map[N](f: M => N): Html[N]
+  def innerHtml(html: String): Html[M]
 
 /** Object used to provide Html syntax `import tyrian.Html.*`
   */
@@ -81,6 +82,9 @@ object Aria extends AriaAttributes
 final case class Tag[+M](name: String, attributes: List[Attr[M]], children: List[Elem[M]]) extends Html[M]:
   def map[N](f: M => N): Tag[N] =
     Tag(name, attributes.map(_.map(f)), children.map(_.map(f)))
+  
+  def innerHtml(html: String): RawTag[M] =
+    RawTag(name, attributes, html)
 
 /** An HTML tag with raw HTML rendered inside. Beware that the inner HTML is not validated to be correct, nor does it
   * get modified as a response to messages in any way.
@@ -88,3 +92,6 @@ final case class Tag[+M](name: String, attributes: List[Attr[M]], children: List
 final case class RawTag[+M](name: String, attributes: List[Attr[M]], innerHTML: String) extends Html[M]:
   def map[N](f: M => N): RawTag[N] =
     RawTag(name, attributes.map(_.map(f)), innerHTML)
+  
+  def innerHtml(html: String): RawTag[M] =
+    RawTag(name, attributes, html)


### PR DESCRIPTION
Building on the `RawTag` work provided by @daniel-ciocirlan, this small change allows you to do this:

```scala
div(id := "mousepos")().innerHtml(s"<p><i>Mouse Coords ${model.mousePosition}</i></p>")
```

![image](https://user-images.githubusercontent.com/908709/212463925-48ff14be-1103-491c-9e75-d0759689f3b8.png)
