### PR TITLE
Add LocalRootProject to fix sourcemaps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val commonJsSettings: Seq[sbt.Def.Setting[_]] = Seq(
   Test / scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
   scalacOptions ++= {
     // Map the sourcemaps to github paths instead of local directories
-    val localSourcesPath = baseDirectory.value.toURI
+    val localSourcesPath = (LocalRootProject / baseDirectory).value.toURI
     val headCommit       = git.gitHeadCommit.value.get
     scmInfo.value.map { info =>
       val remoteSourcesPath =


### PR DESCRIPTION
This should actually fix the sourcemaps(fingers crossed), I forgot to use this like `sbt-typelevel` does.