### PR TITLE
Cmd: add Eq & Functor instances + law checks

### DIFF
--- a/tyrian/js/src/main/scala/tyrian/runtime/CmdHelper.scala
+++ b/tyrian/js/src/main/scala/tyrian/runtime/CmdHelper.scala
@@ -1,13 +1,13 @@
 package tyrian.runtime
 
-import cats.effect.kernel.Concurrent
+import cats.Applicative
 import tyrian.Cmd
 
 import scala.annotation.tailrec
 
 object CmdHelper:
 
-  def cmdToTaskList[F[_]: Concurrent, Msg](cmd: Cmd[F, Msg]): List[F[Option[Msg]]] =
+  def cmdToTaskList[F[_]: Applicative, Msg](cmd: Cmd[F, Msg]): List[F[Option[Msg]]] =
     @tailrec
     def rec(remaining: List[Cmd[F, Msg]], acc: List[F[Option[Msg]]]): List[F[Option[Msg]]] =
       remaining match
@@ -20,13 +20,13 @@ object CmdHelper:
               rec(cmds, acc)
 
             case Cmd.Emit(msg) =>
-              rec(cmds, Concurrent[F].pure(Option(msg)) :: acc)
+              rec(cmds, Applicative[F].pure(Option(msg)) :: acc)
 
             case Cmd.SideEffect(task) =>
-              rec(cmds, Concurrent[F].map(task)(_ => Option.empty[Msg]) :: acc)
+              rec(cmds, Applicative[F].map(task)(_ => Option.empty[Msg]) :: acc)
 
             case Cmd.Run(task, f) =>
-              rec(cmds, Concurrent[F].map(task)(p => Option(f(p))) :: acc)
+              rec(cmds, Applicative[F].map(task)(p => Option(f(p))) :: acc)
 
             case Cmd.Combine(cmd1, cmd2) =>
               rec(cmd1 :: cmd2 :: cmds, acc)

--- a/tyrian/js/src/test/scala/tyrian/CmdLawsTest.scala
+++ b/tyrian/js/src/test/scala/tyrian/CmdLawsTest.scala
@@ -1,0 +1,26 @@
+package tyrian
+
+import cats.Id
+import cats.kernel.laws.discipline.EqTests
+import cats.kernel.laws.discipline.MonoidTests
+import cats.laws.discipline.FunctorTests
+import cats.syntax.foldable.*
+import org.scalacheck.Arbitrary
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
+import tyrian.runtime.CmdHelper
+
+class CmdLawsTests extends munit.DisciplineSuite {
+
+  given [A: Arbitrary]: Arbitrary[Cmd[Id, A]] =
+    Arbitrary(Arbitrary.arbitrary[A].map(Cmd.emit))
+
+  given [A: Cogen]: Cogen[Cmd[Id, A]] =
+    Cogen[List[Id[Option[A]]]].contramap(CmdHelper.cmdToTaskList)
+
+  checkAll("Eq[Cmd]", EqTests[Cmd[Id, Int]].eqv)
+  checkAll("Functor[Cmd]", FunctorTests[Cmd[Id, *]].functor[Int, Double, String])
+  checkAll("Monoid[Cmd]", MonoidTests[Cmd[Id, String]].monoid)
+
+}

--- a/tyrian/js/src/test/scala/tyrian/SubLawsTest.scala
+++ b/tyrian/js/src/test/scala/tyrian/SubLawsTest.scala
@@ -4,23 +4,20 @@ import cats.effect.IO
 import cats.kernel.laws.discipline.EqTests
 import cats.kernel.laws.discipline.MonoidTests
 import cats.laws.discipline.FunctorTests
+import cats.syntax.foldable.*
 import org.scalacheck.Arbitrary
 import org.scalacheck.Cogen
 import org.scalacheck.Gen
 import org.scalacheck.rng.Seed
+import tyrian.runtime.SubHelper
 
 class SubLawsTests extends munit.DisciplineSuite {
 
   given [A: Arbitrary]: Arbitrary[Sub[IO, A]] =
     Arbitrary(Arbitrary.arbitrary[A].map(Sub.emit))
 
-  val cogenValue: Sub[IO, Int] => Long =
-    case Sub.None             => 0L
-    case Sub.Observe(_, _, _) => 1L
-    case Sub.Combine(x, y)    => 2L + cogenValue(x) + cogenValue(y)
-    case Sub.Batch(xs)        => xs.foldLeft(3L)((acc, sub) => acc + cogenValue(sub))
-
-  given Cogen[Sub[IO, Int]] = Cogen(cogenValue)
+  given [A: Cogen]: Cogen[Sub[IO, A]] =
+    Cogen[List[String]].contramap(SubHelper.flatten(_).map(_.id))
 
   checkAll("Eq[Sub]", EqTests[Sub[IO, Int]].eqv)
   checkAll("Functor[Sub]", FunctorTests[Sub[IO, *]].functor[Int, Double, String])


### PR DESCRIPTION
Follow up to the previous `Sub` work. I initially had this implementation, but then I realized an instance based on the helpers was much easier (and perhaps more correct) to define and understand. 

```scala
  given [A: Cogen]: Cogen[Sub[IO, A]] =
    def f: (Seed, Sub[IO, A]) => Seed =
      case (seed, Sub.None) =>
        Cogen.perturb(seed, ())
      case (seed, Sub.Observe(id, _, _)) =>
        Cogen.perturb(seed, id)
      case (seed, Sub.Combine(x, y)) =>
        (x, y).foldLeft(seed)((s1, sub) => f(s1, sub))
      case (seed, Sub.Batch(xs)) =>
        xs.foldLeft(seed)((s1, sub) => f(s1, sub))

    Cogen[Sub[IO, A]](f)
```

So I went for it 🥇 

```scala
 given [A: Cogen]: Cogen[Sub[IO, A]] =
    Cogen[List[String]].contramap(SubHelper.flatten(_).map(_.id))
```