### PR TITLE
Use a blocking queue for WebSocketEvents.

### DIFF
--- a/tyrian/js/src/main/scala/tyrian/runtime/CmdHelper.scala
+++ b/tyrian/js/src/main/scala/tyrian/runtime/CmdHelper.scala
@@ -1,15 +1,17 @@
 package tyrian.runtime
 
 import cats.Applicative
+import cats.effect.std.Dispatcher
 import tyrian.Cmd
 
 import scala.annotation.tailrec
 
 object CmdHelper:
 
-  def cmdToTaskList[F[_]: Applicative, Msg](cmd: Cmd[F, Msg]): List[F[Option[Msg]]] =
+  def cmdToTaskList[F[_]: Applicative, Msg](cmd: Cmd[F, Msg],
+    disp: Dispatcher[F]): List[F[Option[Msg]]] =
     @tailrec
-    def rec(remaining: List[Cmd[F, Msg]], acc: List[F[Option[Msg]]]): List[F[Option[Msg]]] =
+    def rec[A](remaining: List[Cmd[F, Msg]], acc: List[F[Option[Msg]]]): List[F[Option[Msg]]] =
       remaining match
         case Nil =>
           acc.reverse
@@ -27,6 +29,12 @@ object CmdHelper:
 
             case Cmd.Run(task, f) =>
               rec(cmds, Applicative[F].map(task)(p => Option(f(p))) :: acc)
+
+            case Cmd.BuildRun(build, f) =>
+              // XXX - How to get rid of these casts?
+              val castBuild = build.asInstanceOf[Dispatcher[F] => F[A]]
+              val castF = f.asInstanceOf[A => Msg]
+              rec(cmds, Applicative[F].map(castBuild(disp))(p => Option(castF(p))) :: acc)
 
             case Cmd.Combine(cmd1, cmd2) =>
               rec(cmd1 :: cmd2 :: cmds, acc)

--- a/tyrian/js/src/main/scala/tyrian/runtime/TyrianRuntime.scala
+++ b/tyrian/js/src/main/scala/tyrian/runtime/TyrianRuntime.scala
@@ -61,7 +61,7 @@ final class TyrianRuntime[F[_]: Async, Model, Msg](
   ): F[List[F[Unit]]] =
     Async[F].delay {
       // Cmds
-      val cmdsToRun = CmdHelper.cmdToTaskList(cmd)
+      val cmdsToRun = CmdHelper.cmdToTaskList(cmd, dispatcher)
 
       // Subs
       val allSubs                 = SubHelper.flatten(sub)


### PR DESCRIPTION
Hello there.

I would like to explore a new draft proposal, which actually solves the issue for me. It's not a particularly elegant abstraction and it also has a few known issues, but on the other hand it's a pretty minimal set of changes that are invisible from the user's perspective as far as I can tell. Maybe it can be turned into or inspire something useful.

* I added a new command, `BuildRun`. It wraps a function, `build`, that basically produces a `Run` from a `Dispatcher`. That's what `WebSocket.connect` now returns instead of a `Run`.
* `cmdToTaskList` now takes a `Dispatcher` so that it can deal with `BuildRun`s: apply `build` to the `Dispatcher`, then treat the result just like a `Run`.
* Inside the `BuildRun`, the `Dispatcher` is threaded down to `newConnection`, which uses it to push elements on the queue.

Unresolved issues (see the `XXX` marks in the code):

* How would one now define equality on commands? For now, I've commented it out.
* There are two type casts in `cmdToTaskList`, in the code that processes the `BuildRun`. I don't understand why I need them. Without them, Scala doesn't see that, for example, the `F` in the type of `build` is identical to the `F` in `cmdToTaskList`'s type signature.
* Is there a way to bring `flatMap` into scope so that we can use a for-comprehension in `newConnection`?

Oh, and some of the lines have gotten really long. Is there a style guide for the Tyrian code?
