### PR TITLE
Use FS2 `Channel` for `WebSocket`

### DIFF
--- a/tyrian/js/src/main/scala/tyrian/websocket/WebSocket.scala
+++ b/tyrian/js/src/main/scala/tyrian/websocket/WebSocket.scala
@@ -18,8 +18,7 @@ import scala.concurrent.duration.*
 final class WebSocket[F[_]: Async](liveSocket: LiveSocket[F]):
   /** Disconnect from this WebSocket */
   def disconnect[Msg]: Cmd[F, Msg] =
-    Cmd.SideEffect(liveSocket.socket.close(1000, "Graceful shutdown"))
-      .combine(Cmd.SideEffect(liveSocket.closeChannel))
+    Cmd.SideEffect(Async[F].delay(liveSocket.socket.close(1000, "Graceful shutdown")) *> liveSocket.closeChannel)
 
   /** Publish a message to this WebSocket */
   def publish[Msg](message: String): Cmd[F, Msg] =


### PR DESCRIPTION
Sorry, I got nerd-sniped 😸 cc @uncle-betty

Like https://github.com/PurpleKingdomGames/tyrian/pull/175, https://github.com/PurpleKingdomGames/tyrian/pull/176, this replaces the busy-loop polling of a mutable queue used to implement `WebSocket`. Instead of using a Cats Effect `Queue`, it uses an FS2 `Channel`, which is optimized for consuming as a `Stream`.

Unlike https://github.com/PurpleKingdomGames/tyrian/pull/176, the `Dispatcher` is not threaded through the runtime. It is kept local to the websocket, so it does not require changes to the runtime.

This PR implements precisely what I said in https://github.com/PurpleKingdomGames/tyrian/pull/175#issuecomment-1468948238: the websocket is a resource, that is _already_ going in the model, so it is no extra effort to handle the `Channel` and `Dispatcher` resources along with it.

PR is best reviewed with whitespace hidden.