### PR TITLE
Fixed #173: Added Cmd.toTask

### DIFF
--- a/tyrian/js/src/main/scala/tyrian/runtime/CmdHelper.scala
+++ b/tyrian/js/src/main/scala/tyrian/runtime/CmdHelper.scala
@@ -19,14 +19,14 @@ object CmdHelper:
             case Cmd.None =>
               rec(cmds, acc)
 
-            case Cmd.Emit(msg) =>
-              rec(cmds, Applicative[F].pure(Option(msg)) :: acc)
+            case c: Cmd.Emit[_] =>
+              rec(cmds, Applicative[F].map(c.toTask)(Option.apply) :: acc)
 
-            case Cmd.SideEffect(task) =>
-              rec(cmds, Applicative[F].map(task)(_ => Option.empty[Msg]) :: acc)
+            case c: Cmd.SideEffect[_] =>
+              rec(cmds, Applicative[F].map(c.toTask)(_ => Option.empty[Msg]) :: acc)
 
-            case Cmd.Run(task, f) =>
-              rec(cmds, Applicative[F].map(task)(p => Option(f(p))) :: acc)
+            case c: Cmd.Run[_, _, _] =>
+              rec(cmds, Applicative[F].map(c.toTask)(Option.apply) :: acc)
 
             case Cmd.Combine(cmd1, cmd2) =>
               rec(cmd1 :: cmd2 :: cmds, acc)

--- a/tyrian/js/src/main/scala/tyrian/syntax.scala
+++ b/tyrian/js/src/main/scala/tyrian/syntax.scala
@@ -1,5 +1,6 @@
 package tyrian
 
+import cats.Applicative
 import cats.effect.Async
 
 object syntax:
@@ -12,7 +13,7 @@ object syntax:
 
   /** Make a cmd from any `F[A]`
     */
-  extension [F[_], A](task: F[A])
+  extension [F[_]: Applicative, A](task: F[A])
     def toCmd: Cmd.Run[F, A, A] =
       Cmd.Run(task)(identity)
 


### PR DESCRIPTION
Relates to #173 

The idea is that sometimes you want to build up a computation that starts with an existing `Cmd` and do something with it in terms of it's underlying task. For example you might want to race three HTTP calls, and you can do that by calling `toTask` on the `Cmd`.

Thoughts and feedback welcome from more experienced cat wranglers. :cat: 

