### PR TITLE
Remove redundant closing in WebSocket implementation

### DIFF
--- a/tyrian/js/src/main/scala/tyrian/websocket/WebSocket.scala
+++ b/tyrian/js/src/main/scala/tyrian/websocket/WebSocket.scala
@@ -33,7 +33,7 @@ final class WebSocket[F[_]: Async](liveSocket: LiveSocket[F]):
 /** The running instance of the WebSocket */
 final class LiveSocket[F[_]: Async](
     val socket: dom.WebSocket,
-    val subs: Sub[F, WebSocketEvent],
+    val subs: Sub[F, WebSocketEvent]
 )
 
 enum WebSocketReadyState derives CanEqual:

--- a/tyrian/js/src/main/scala/tyrian/websocket/WebSocket.scala
+++ b/tyrian/js/src/main/scala/tyrian/websocket/WebSocket.scala
@@ -125,17 +125,14 @@ object WebSocket:
             val msg =
               try e.asInstanceOf[dom.ErrorEvent].message
               catch { case _: Throwable => "Unknown" }
-            dispatcher.unsafeRunAndForget(
-              channel.send(WebSocketEvent.Error(msg)) *>
-                close.start // can't close the dispatcher from the dispatcher, so we start a new fiber
-            )
+            dispatcher.unsafeRunAndForget(channel.send(WebSocketEvent.Error(msg)))
           }
 
           val closeListener = Functions.fun { e =>
             val ev = e.asInstanceOf[dom.CloseEvent]
             dispatcher.unsafeRunAndForget(
               channel.send(WebSocketEvent.Close(ev.code, ev.reason)) *>
-                close.start // ditto
+                close.start // can't close the dispatcher from the dispatcher, so we start a new fiber
             )
           }
 

--- a/tyrian/js/src/main/scala/tyrian/websocket/WebSocket.scala
+++ b/tyrian/js/src/main/scala/tyrian/websocket/WebSocket.scala
@@ -19,16 +19,7 @@ import scala.concurrent.duration.*
 final class WebSocket[F[_]: Async](liveSocket: LiveSocket[F]):
   /** Disconnect from this WebSocket */
   def disconnect[Msg]: Cmd[F, Msg] =
-    Cmd.SideEffect {
-      Async[F].async_[Unit] { cb =>
-        liveSocket.socket.close(1000, "Graceful shutdown")
-        liveSocket.socket.addEventListener(
-          "close",
-          _ => cb(Either.unit),
-          new dom.EventListenerOptions { once = true }
-        )
-      } *> liveSocket.closeChannel
-    }
+    Cmd.SideEffect(Async[F].delay(liveSocket.socket.close(1000, "Graceful shutdown")) *> liveSocket.closeChannel)
 
   /** Publish a message to this WebSocket */
   def publish[Msg](message: String): Cmd[F, Msg] =

--- a/tyrian/js/src/main/scala/tyrian/websocket/WebSocket.scala
+++ b/tyrian/js/src/main/scala/tyrian/websocket/WebSocket.scala
@@ -19,7 +19,7 @@ import scala.concurrent.duration.*
 final class WebSocket[F[_]: Async](liveSocket: LiveSocket[F]):
   /** Disconnect from this WebSocket */
   def disconnect[Msg]: Cmd[F, Msg] =
-    Cmd.SideEffect(Async[F].delay(liveSocket.socket.close(1000, "Graceful shutdown")) *> liveSocket.closeChannel)
+    Cmd.SideEffect(Async[F].delay(liveSocket.socket.close(1000, "Graceful shutdown")))
 
   /** Publish a message to this WebSocket */
   def publish[Msg](message: String): Cmd[F, Msg] =
@@ -34,7 +34,6 @@ final class WebSocket[F[_]: Async](liveSocket: LiveSocket[F]):
 final class LiveSocket[F[_]: Async](
     val socket: dom.WebSocket,
     val subs: Sub[F, WebSocketEvent],
-    val closeChannel: F[Unit]
 )
 
 enum WebSocketReadyState derives CanEqual:
@@ -161,7 +160,7 @@ object WebSocket:
               keepAlive.run
             )
 
-          LiveSocket(socket, subs, close)
+          LiveSocket(socket, subs)
         }
     }
 


### PR DESCRIPTION
Hopefully fixes https://github.com/PurpleKingdomGames/tyrian/issues/184.

cc @uncle-betty thanks for investigating this so thoroughly!

Update: because the `'close'` event is guaranteed to be called even in case of error, we can move all on-close handling to there.