### PR TITLE
Issue/178/bug property types

### DIFF
--- a/project/AttributeGen.scala
+++ b/project/AttributeGen.scala
@@ -11,10 +11,13 @@ object AttributeGen {
           else "value.toString"
         })
       |
-      |  final class PropertyName$typ(name: String):
-      |    def :=(value: $typ): Property = Property(name.toString, ${
-          if (typ == "String") "value" else "value.toString"
-        })
+      |""".stripMargin
+    }.mkString
+
+  def generatePropertyNameTypes: String =
+    List("String", "Boolean").map { typ =>
+      s"""  final class PropertyName$typ(name: String):
+      |    def :=(value: $typ): Property$typ = Property$typ(name.toString, value)
       |
       |""".stripMargin
     }.mkString
@@ -110,6 +113,7 @@ object AttributeGen {
 
         val contents: String =
           generateAttributeNameTypes +
+            generatePropertyNameTypes +
             genAttributesAndProperties +
             "\n\n  // Attributes\n\n" +
             attrs.map(a => genAttr(a, true)).mkString +
@@ -298,7 +302,7 @@ object AttributeGen {
       Normal("rowspan").withTypes("String", "Int"),
       NoValue("sandbox"),
       Normal("scope"),
-      NoValue("selected"),
+      NoValue("selected"), // property
       Normal("shape"),
       Normal("size").withTypes("String", "Int"),
       Normal("sizes"),

--- a/project/AttributeGen.scala
+++ b/project/AttributeGen.scala
@@ -22,8 +22,8 @@ object AttributeGen {
   def genAttributesAndProperties: String =
     s"""  def attribute(name: String, value: String): Attr[Nothing]  = Attribute(name, value)
     |  def attributes(as: (String, String)*): List[Attr[Nothing]] = as.toList.map(p => Attribute(p._1, p._2))
-    |  def property(name: String, value: String): Attr[Nothing]   = Property(name, value)
-    |  def properties(ps: (String, String)*): List[Attr[Nothing]] = ps.toList.map(p => Property(p._1, p._2))
+    |  def property(name: String, value: Boolean | String): Attr[Nothing]   = Property(name, value)
+    |  def properties(ps: (String, Boolean | String)*): List[Attr[Nothing]] = ps.toList.map(p => Property(p._1, p._2))
     |
     |  def onEvent[E <: Tyrian.Event, M](name: String, msg: E => M): Attr[M] = Event(name, msg)
     |""".stripMargin
@@ -140,7 +140,7 @@ object AttributeGen {
       NoValue("autoPlay"),
       NoValue("autoplay"),
       Normal("charset"),
-      NoValue("checked"),
+      NoValue("checked"), // property
       Normal("cite"),
       Normal("`class`", "class"),
       Normal("cls", "class"),
@@ -332,7 +332,10 @@ object AttributeGen {
 
   def htmlProps: List[Normal] =
     List(
-      Normal("value").withTypes("String", "Double", "Boolean")
+      Normal("checked").withTypes("Boolean"),
+      Normal("indeterminate").withTypes("Boolean"),
+      Normal("selected").withTypes("Boolean"),
+      Normal("value").withTypes("String")
     )
 
   def svgAttrs: List[AttributeType] = List(

--- a/sandbox/src/main/scala/example/Sandbox.scala
+++ b/sandbox/src/main/scala/example/Sandbox.scala
@@ -420,7 +420,7 @@ object Sandbox extends TyrianApp[Msg, Model]:
               text("Timeout: "),
               input(
                 placeholder := "timeout",
-                value       := model.http.timeout,
+                value       := model.http.timeout.toString,
                 onInput(s => Msg.UpdateHttpTimeout(s))
               )
             ),

--- a/sandbox/src/main/scala/example/Sandbox.scala
+++ b/sandbox/src/main/scala/example/Sandbox.scala
@@ -318,7 +318,7 @@ object Sandbox extends TyrianApp[Msg, Model]:
               Html.span(
                 label(fruit.name),
                 input(
-                  typ := "checkbox",
+                  typ     := "checkbox",
                   checked := fruit.available,
                   onChange(_ => Msg.ToggleFruitAvailability(fruit.name))
                 )

--- a/tyrian/js/src/main/scala/tyrian/runtime/Rendering.scala
+++ b/tyrian/js/src/main/scala/tyrian/runtime/Rendering.scala
@@ -10,6 +10,8 @@ import tyrian.Event
 import tyrian.Html
 import tyrian.NamedAttribute
 import tyrian.Property
+import tyrian.PropertyBoolean
+import tyrian.PropertyString
 import tyrian.RawTag
 import tyrian.Tag
 import tyrian.Text
@@ -24,7 +26,10 @@ object Rendering:
       }
 
     val props: List[(String, PropValue)] =
-      attrs.collect { case Property(n, v) => (n, v) }
+      attrs.collect {
+        case PropertyString(n, v)  => (n, v)
+        case PropertyBoolean(n, v) => (n, v)
+      }
 
     val events: List[(String, EventHandler)] =
       attrs.collect { case Event(n, msg) =>

--- a/tyrian/js/src/test/scala/tyrian/HtmlTests.scala
+++ b/tyrian/js/src/test/scala/tyrian/HtmlTests.scala
@@ -71,9 +71,9 @@ class HtmlTests extends munit.FunSuite {
   test("'value' property can have different types") {
 
     val attr1 = value := "fish"
-    val attr2 = value := "10"
-    val attr3 = value := "101.5d"
-    val attr4 = value := "true"
+    val attr2 = value := 10.toString
+    val attr3 = value := 101.5d.toString
+    val attr4 = value := true.toString
 
     assert(clue(attr1.name) == "value")
     assert(clue(attr1.value) == "fish")

--- a/tyrian/js/src/test/scala/tyrian/HtmlTests.scala
+++ b/tyrian/js/src/test/scala/tyrian/HtmlTests.scala
@@ -68,12 +68,12 @@ class HtmlTests extends munit.FunSuite {
 
   }
 
-  test("'value' attribute can have different types") {
+  test("'value' property can have different types") {
 
     val attr1 = value := "fish"
-    val attr2 = value := 10
-    val attr3 = value := 101.5d
-    val attr4 = value := true
+    val attr2 = value := "10"
+    val attr3 = value := "101.5d"
+    val attr4 = value := "true"
 
     assert(clue(attr1.name) == "value")
     assert(clue(attr1.value) == "fish")

--- a/tyrian/shared/src/main/scala/tyrian/runtime/TyrianSSR.scala
+++ b/tyrian/shared/src/main/scala/tyrian/runtime/TyrianSSR.scala
@@ -70,4 +70,9 @@ object Render:
 
   extension (p: Property)
     def render: String =
-      s"""${p.name}="${p.value}""""
+      val asStr: String =
+        p.valueOf match
+          case x: Boolean => x.toString
+          case x: String  => x
+
+      s"""${p.name}="${asStr}""""


### PR DESCRIPTION
Fixes #178.

The specific case we had involved (in HTML) `checked`, like this:

`<input type="checkbox" checked>foo</input>`

Where I mistakenly thought that modifying the presence of `checked` would toggle the checkbox on and off. Not so, `checked` as used above is an attribute that defines the state of the checkbox _on page load_ but not after.

In order to programmatically check the box after page load you need to modify the _property_ `checked`, not the attribute. It's to do with [IDL](https://developer.mozilla.org/en-US/docs/Glossary/IDL) and how that reflects the value of the attributes, or not.  Luckily there do not appear to be many attributes where it's really necessary to define a corresponding property. The list is:

- value (String)
- selected (Boolean)
- checked (Boolean)
- indeterminate (Boolean) - when a checkbox is neither selected or unselected for example.

There are others like `defaultChecked`, but that seems irrelevant in a VirtualDom scenario, since we already know whether or not an input was checked at page load time.

So this PR adds typed properties for those mentioned, and also now restricts `value` to being just a `String`. `value` always was a string really but we had convenience methods to help you use other types.

In the case of `checked`, you can now do this:

```scala
checked // attribute - is checked at page load
checked(true|false) // attribute - is/isn't checked at page load
checked := true|false // property - checks and unchecks at any time.
```