### PR TITLE
Fixed #110: Event.preventDefault support

### DIFF
--- a/project/AttributeGen.scala
+++ b/project/AttributeGen.scala
@@ -28,7 +28,7 @@ object AttributeGen {
     |  def property(name: String, value: Boolean | String): Attr[Nothing]   = Property(name, value)
     |  def properties(ps: (String, Boolean | String)*): List[Attr[Nothing]] = ps.toList.map(p => Property(p._1, p._2))
     |
-    |  def onEvent[E <: Tyrian.Event, M](name: String, msg: E => M): Attr[M] = Event(name, msg)
+    |  def onEvent[E <: Tyrian.Event, M](name: String, msg: E => M): Event[E, M] = Event(name, msg)
     |""".stripMargin
 
   def genAttr(tag: AttributeType, isAttribute: Boolean): String =
@@ -77,12 +77,12 @@ object AttributeGen {
     }
     eventType match {
       case Some(evt) =>
-        s"""  def $attrName[M](msg: Tyrian.$evt => M): Attr[M] = onEvent("$attr", msg)
+        s"""  def $attrName[M](msg: Tyrian.$evt => M): Event[Tyrian.$evt, M] = onEvent("$attr", msg)
         |
         |""".stripMargin
 
       case None =>
-        s"""  def $attrName[M](msg: M): Attr[M] = onEvent("$attr", (_: Tyrian.Event) => msg)
+        s"""  def $attrName[M](msg: M): Event[Tyrian.Event, M] = onEvent("$attr", (_: Tyrian.Event) => msg)
         |
         |""".stripMargin
     }

--- a/sandbox/src/main/scala/example/Sandbox.scala
+++ b/sandbox/src/main/scala/example/Sandbox.scala
@@ -509,19 +509,8 @@ object Sandbox extends TyrianApp[Msg, Model]:
           )
 
         case Page.Page6 =>
-          // Example of how to use preventDefault to avoid a page refesh on form submit.
-          val submitMyForm =
-            Html.onEvent(
-              "submit",
-              { (e: Tyrian.Event) =>
-                e.preventDefault()
-                Msg.Log("submitted")
-              }
-            )
-
           div(
-            // form(onSubmit(Msg.Log("submitted")))( // Refreshes the page
-            form(submitMyForm)(
+            form(onSubmit(Msg.Log("submitted")))(
               input(_type := "submit", name := "submit", value := "submit")
             )
           )

--- a/tyrian/js/src/main/scala/tyrian/runtime/Rendering.scala
+++ b/tyrian/js/src/main/scala/tyrian/runtime/Rendering.scala
@@ -32,8 +32,16 @@ object Rendering:
       }
 
     val events: List[(String, EventHandler)] =
-      attrs.collect { case Event(n, msg) =>
-        (n, EventHandler((e: dom.Event) => onMsg(msg.asInstanceOf[dom.Event => Msg](e))))
+      attrs.collect { case Event(n, msg, preventDefault, stopPropagation, stopImmediatePropagation) =>
+        val callback: dom.Event => Unit = { (e: dom.Event) =>
+          if preventDefault then e.preventDefault()
+          if stopPropagation then e.stopPropagation()
+          if stopImmediatePropagation then e.stopImmediatePropagation()
+
+          onMsg(msg.asInstanceOf[dom.Event => Msg](e))
+        }
+
+        (n, EventHandler(callback))
       }
 
     VNodeData.empty.copy(

--- a/tyrian/js/src/main/scala/tyrian/runtime/TyrianRuntime.scala
+++ b/tyrian/js/src/main/scala/tyrian/runtime/TyrianRuntime.scala
@@ -9,10 +9,7 @@ import fs2.concurrent.Channel
 import org.scalajs.dom
 import org.scalajs.dom.Element
 import snabbdom.VNode
-import tyrian.Attr
-import tyrian.Attribute
 import tyrian.Cmd
-import tyrian.Event
 import tyrian.Html
 import tyrian.Sub
 

--- a/tyrian/shared/src/main/scala/tyrian/Attr.scala
+++ b/tyrian/shared/src/main/scala/tyrian/Attr.scala
@@ -93,16 +93,20 @@ final case class Event[E <: Tyrian.Event, M](
     stopPropagation: Boolean,
     stopImmediatePropagation: Boolean
 ) extends Attr[M]:
-  def map[N](f: M => N): Attr[N]                  = Event(name, msg andThen f)
-  def preventDefaultToggle: Event[E, M]           = this.copy(preventDefault = !preventDefault)
-  def preventDefaultOn: Event[E, M]               = this.copy(preventDefault = true)
-  def preventDefaultOff: Event[E, M]              = this.copy(preventDefault = false)
-  def stopPropagationToggle: Event[E, M]          = this.copy(stopPropagation = !stopPropagation)
-  def stopPropagationOn: Event[E, M]              = this.copy(stopPropagation = true)
-  def stopPropagationOff: Event[E, M]             = this.copy(stopPropagation = false)
-  def stopImmediatePropagationToggle: Event[E, M] = this.copy(stopImmediatePropagation = !stopImmediatePropagation)
-  def stopImmediatePropagationOn: Event[E, M]     = this.copy(stopImmediatePropagation = true)
-  def stopImmediatePropagationOff: Event[E, M]    = this.copy(stopImmediatePropagation = false)
+  def map[N](f: M => N): Attr[N] = Event(name, msg andThen f)
+
+  def withPreventDefault(enabled: Boolean): Event[E, M] = this.copy(preventDefault = enabled)
+  def usePreventDefault: Event[E, M]                    = withPreventDefault(true)
+  def noPreventDefault: Event[E, M]                     = withPreventDefault(false)
+
+  def withStopPropagation(enabled: Boolean): Event[E, M] = this.copy(stopPropagation = enabled)
+  def useStopPropagation: Event[E, M]                    = withStopPropagation(true)
+  def noStopPropagation: Event[E, M]                     = withStopPropagation(false)
+
+  def withStopImmediatePropagation(enabled: Boolean): Event[E, M] = this.copy(stopImmediatePropagation = enabled)
+  def useStopImmediatePropagation: Event[E, M]                    = withStopImmediatePropagation(true)
+  def noStopImmediatePropagation: Event[E, M]                     = withStopImmediatePropagation(false)
+
 object Event:
   def apply[E <: Tyrian.Event, M](name: String, msg: E => M): Event[E, M] =
     Event(

--- a/tyrian/shared/src/main/scala/tyrian/Attr.scala
+++ b/tyrian/shared/src/main/scala/tyrian/Attr.scala
@@ -86,5 +86,29 @@ object Property:
   * @param msg
   *   Message to produce when the event is triggered
   */
-final case class Event[E <: Tyrian.Event, M](name: String, msg: E => M) extends Attr[M]:
-  def map[N](f: M => N): Attr[N] = Event(name, msg andThen f)
+final case class Event[E <: Tyrian.Event, M](
+    name: String,
+    msg: E => M,
+    preventDefault: Boolean,
+    stopPropagation: Boolean,
+    stopImmediatePropagation: Boolean
+) extends Attr[M]:
+  def map[N](f: M => N): Attr[N]                  = Event(name, msg andThen f)
+  def preventDefaultToggle: Event[E, M]           = this.copy(preventDefault = !preventDefault)
+  def preventDefaultOn: Event[E, M]               = this.copy(preventDefault = true)
+  def preventDefaultOff: Event[E, M]              = this.copy(preventDefault = false)
+  def stopPropagationToggle: Event[E, M]          = this.copy(stopPropagation = !stopPropagation)
+  def stopPropagationOn: Event[E, M]              = this.copy(stopPropagation = true)
+  def stopPropagationOff: Event[E, M]             = this.copy(stopPropagation = false)
+  def stopImmediatePropagationToggle: Event[E, M] = this.copy(stopImmediatePropagation = !stopImmediatePropagation)
+  def stopImmediatePropagationOn: Event[E, M]     = this.copy(stopImmediatePropagation = true)
+  def stopImmediatePropagationOff: Event[E, M]    = this.copy(stopImmediatePropagation = false)
+object Event:
+  def apply[E <: Tyrian.Event, M](name: String, msg: E => M): Event[E, M] =
+    Event(
+      name = name,
+      msg = msg,
+      preventDefault = true,
+      stopPropagation = true,
+      stopImmediatePropagation = true
+    )


### PR DESCRIPTION
Resolves #110.

Events now `preventDefault`, `stopPropagation`, and `stopImmediatePropagation` by default, because have read around the subject, this seems like the behaviour we want in an Elm-like application.

I have expanded the API so that you can do things like `preventDefaultOn`, `preventDefaultOff`, `preventDefaultToggle`, in case you want the standard behaviour:

```scala
form(onSubmit(Msg.Log("submitted").preventDefaultOff))(
  input(_type := "submit", name := "submit", value := "submit")
)
```

I don't know if this is the most elegant solution, but it gets around the immediate problems and provides and more sensible default. We can always improve on this later.