### PR TITLE
#193 CSS properties in camel-case

### DIFF
--- a/project/CSSGen.scala
+++ b/project/CSSGen.scala
@@ -3,8 +3,22 @@ import scala.sys.process._
 
 object CSSGen {
 
-  def genCssProp(name: String): String =
-    s"""  def `$name`(value: String): Style = Style("$name", value)"""
+  def genCssProp(name: String): String = {
+    val cssProp = s"""  def `$name`(value: String): Style = Style("$name", value)"""
+    if (!name.contains("-") || name.contains("@")) { 
+      cssProp
+    } else {
+      val nameCC: String = name.split("-").toList match {
+        case Nil =>
+  	  throw new Exception(s"CSS property '$name' was unexpectedly empty")
+        case head :: tail =>
+  	  (head :: tail.map(_.capitalize)).mkString
+      }
+      s"""$cssProp 
+      |  def ${nameCC}(value: String): Style = Style("$name", value)
+      |""".stripMargin
+    }
+  }
 
   def template(moduleName: String, fullyQualifiedPath: String, contents: String): String =
     s"""package $fullyQualifiedPath


### PR DESCRIPTION
I'm not sure if this is the correct way to go about this or if there is an easier way to alias imports that don't require the function to be redefined. 

example prop: animation-delay
output
```
  def `animation-delay`(value: String): Style = Style("animation-delay", value)
  def animationDelay(value: String): Style = Style("animation-delay", value)
```