### PR TITLE
Sub - Observe: remove the F wrapper for observable.

### DIFF
--- a/tyrian/js/src/main/scala/tyrian/runtime/CmdHelper.scala
+++ b/tyrian/js/src/main/scala/tyrian/runtime/CmdHelper.scala
@@ -3,8 +3,8 @@ package tyrian.runtime
 import cats.Applicative
 import tyrian.Cmd
 
-import scala.collection.mutable.ListBuffer
 import scala.annotation.tailrec
+import scala.collection.mutable.ListBuffer
 
 object CmdHelper:
 

--- a/tyrian/js/src/main/scala/tyrian/runtime/SubHelper.scala
+++ b/tyrian/js/src/main/scala/tyrian/runtime/SubHelper.scala
@@ -52,9 +52,7 @@ object SubHelper:
     Resource
       .makeFull[F, Option[F[Unit]]] { poll =>
         poll {
-          sub.observable.flatMap { run =>
-            run(result => callback(result.map(sub.toMsg(_))))
-          }
+          sub.observable(result => callback(result.map(sub.toMsg(_))))
         }
       }(_.getOrElse(F.unit))
       .useForever

--- a/tyrian/js/src/test/scala/tyrian/CmdSubUtils.scala
+++ b/tyrian/js/src/test/scala/tyrian/CmdSubUtils.scala
@@ -24,9 +24,7 @@ object CmdSubUtils:
   def runSub[A, Msg](sub: Sub[IO, Msg])(callback: Either[Throwable, A] => Unit): IO[Unit] =
     sub match
       case s: Sub.Observe[IO, A, Msg] @unchecked =>
-        s.observable.map { run =>
-          run(callback)
-        }
+        s.observable(callback).void
 
       case _ =>
         throw new Exception("failed, was not a run task")

--- a/tyrian/js/src/test/scala/tyrian/SubTests.scala
+++ b/tyrian/js/src/test/scala/tyrian/SubTests.scala
@@ -5,7 +5,7 @@ import cats.effect.IO
 @SuppressWarnings(Array("scalafix:DisableSyntax.throw", "scalafix:DisableSyntax.var"))
 class SubTests extends munit.CatsEffectSuite {
 
-  type Obs[A] = IO[(Either[Throwable, A] => Unit) => IO[Option[IO[Unit]]]]
+  type Obs[A] = (Either[Throwable, A] => Unit) => IO[Option[IO[Unit]]]
 
   import CmdSubUtils.*
 
@@ -17,11 +17,10 @@ class SubTests extends munit.CatsEffectSuite {
       case Left(_)  => throw new Exception("failed")
     }
 
-    val observable: Int => Obs[Int] = i =>
-      IO.delay { cb =>
-        cb(Right(i))
-        IO(Option(IO(())))
-      }
+    val observable: Int => Obs[Int] = i => { cb =>
+      cb(Right(i))
+      IO(Option(IO(())))
+    }
 
     val subs = List(
       Sub.Observe[IO, Int]("sub1", observable(10)),
@@ -63,7 +62,7 @@ class SubTests extends munit.CatsEffectSuite {
       case Left(_)  => throw new Exception("failed")
     }
 
-    val observable: Obs[Int] = IO.delay { cb =>
+    val observable: Obs[Int] = { cb =>
       cb(Right(10))
       IO(Option(IO(())))
     }
@@ -82,11 +81,10 @@ class SubTests extends munit.CatsEffectSuite {
       case Left(_)  => throw new Exception("failed")
     }
 
-    val observable: Int => Obs[Int] = i =>
-      IO.delay { cb =>
-        cb(Right(i))
-        IO(Option(IO(())))
-      }
+    val observable: Int => Obs[Int] = i => { cb =>
+      cb(Right(i))
+      IO(Option(IO(())))
+    }
 
     val combined =
       Sub.Combine(
@@ -108,11 +106,10 @@ class SubTests extends munit.CatsEffectSuite {
       case Left(_)  => throw new Exception("failed")
     }
 
-    val observable: Int => Obs[Int] = i =>
-      IO.delay { cb =>
-        cb(Right(i))
-        IO(Option(IO(())))
-      }
+    val observable: Int => Obs[Int] = i => { cb =>
+      cb(Right(i))
+      IO(Option(IO(())))
+    }
 
     val batched =
       Sub.Batch[IO, Int](
@@ -145,11 +142,10 @@ class SubTests extends munit.CatsEffectSuite {
       case Left(_)  => throw new Exception("failed")
     }
 
-    val observable: Int => Obs[Int] = i =>
-      IO.delay { cb =>
-        cb(Right(i))
-        IO(Option(IO(())))
-      }
+    val observable: Int => Obs[Int] = i => { cb =>
+      cb(Right(i))
+      IO(Option(IO(())))
+    }
 
     val test1 =
       Sub.Batch[IO, Int](


### PR DESCRIPTION
The `observable` field is a task `F` that produces a function. However, since the mutable logic is in the function body, and not in creating the function literal, there is no need to keep that wrapper `F` around.