### PR TITLE
Fix map for Event attributes

### DIFF
--- a/tyrian/js/src/test/scala/tyrian/AttrTests.scala
+++ b/tyrian/js/src/test/scala/tyrian/AttrTests.scala
@@ -9,4 +9,26 @@ class AttrTests extends munit.FunSuite {
     assert(clue(attr.name) == "hidden")
   }
 
+  test("event properties propagate through map") {
+    val event1 = Event("test", _ => (), true, true, true)
+    val event2 = Event("test", _ => (), false, false, false)
+
+    val mapped1 = event1.map(identity)
+    val mapped2 = event2.map(identity)
+
+    (event1, mapped1) match
+      case (Event(a1, _, b1, c1, d1), Event(a2, _, b2, c2, d2)) =>
+        assert(clue(a1 == a2))
+        assert(clue(b1 == b2))
+        assert(clue(c1 == c2))
+        assert(clue(d1 == d2))
+
+    (event2, mapped2) match
+      case (Event(a1, _, b1, c1, d1), Event(a2, _, b2, c2, d2)) =>
+        assert(clue(a1 == a2))
+        assert(clue(b1 == b2))
+        assert(clue(c1 == c2))
+        assert(clue(d1 == d2))
+  }
+
 }

--- a/tyrian/shared/src/main/scala/tyrian/Attr.scala
+++ b/tyrian/shared/src/main/scala/tyrian/Attr.scala
@@ -93,7 +93,7 @@ final case class Event[E <: Tyrian.Event, M](
     stopPropagation: Boolean,
     stopImmediatePropagation: Boolean
 ) extends Attr[M]:
-  def map[N](f: M => N): Attr[N] = this.copy(msg = msg andThen f)
+  def map[N](f: M => N): Event[E, N] = this.copy(msg = msg andThen f)
 
   def withPreventDefault(enabled: Boolean): Event[E, M] = this.copy(preventDefault = enabled)
   def usePreventDefault: Event[E, M]                    = withPreventDefault(true)

--- a/tyrian/shared/src/main/scala/tyrian/Attr.scala
+++ b/tyrian/shared/src/main/scala/tyrian/Attr.scala
@@ -93,7 +93,7 @@ final case class Event[E <: Tyrian.Event, M](
     stopPropagation: Boolean,
     stopImmediatePropagation: Boolean
 ) extends Attr[M]:
-  def map[N](f: M => N): Attr[N] = Event(name, msg andThen f)
+  def map[N](f: M => N): Attr[N] = this.copy(msg = msg andThen f)
 
   def withPreventDefault(enabled: Boolean): Event[E, M] = this.copy(preventDefault = enabled)
   def usePreventDefault: Event[E, M]                    = withPreventDefault(true)

--- a/tyrian/shared/src/main/scala/tyrian/Html.scala
+++ b/tyrian/shared/src/main/scala/tyrian/Html.scala
@@ -88,7 +88,10 @@ object Aria extends AriaAttributes
 /** An HTML tag */
 final case class Tag[+M](name: String, attributes: List[Attr[M]], children: List[Elem[M]]) extends Html[M]:
   def map[N](f: M => N): Tag[N] =
-    Tag(name, attributes.map(_.map(f)), children.map(_.map(f)))
+    this.copy(
+      attributes = attributes.map(_.map(f)),
+      children = children.map(_.map(f))
+    )
 
   def innerHtml(html: String): RawTag[M] =
     RawTag(name, attributes, html)
@@ -98,7 +101,9 @@ final case class Tag[+M](name: String, attributes: List[Attr[M]], children: List
   */
 final case class RawTag[+M](name: String, attributes: List[Attr[M]], innerHTML: String) extends Html[M]:
   def map[N](f: M => N): RawTag[N] =
-    RawTag(name, attributes.map(_.map(f)), innerHTML)
+    this.copy(
+      attributes = attributes.map(_.map(f))
+    )
 
   def innerHtml(html: String): RawTag[M] =
     RawTag(name, attributes, html)


### PR DESCRIPTION
There are two issues present with the map method today:

1. Its return type is widened to Attr
2. It does not propagate all of the properties of the current Event

This means, e.g., if you want to use a pattern where sub-components use their own internal message type which then gets mapped in the parent, events do not map cleanly.

This PR fixes the issues by using the `copy` method. I have extended the usage of `copy` to the other, similar `map` methods, as well, to future-proof in case additional parameters are added to these other attribute classes as seems to have been the case with Event.

