### PR TITLE
Make render loop wait for model updates

### DIFF
--- a/tyrian/js/src/main/scala/tyrian/runtime/ModelHolder.scala
+++ b/tyrian/js/src/main/scala/tyrian/runtime/ModelHolder.scala
@@ -1,3 +1,0 @@
-package tyrian.runtime
-
-final case class ModelHolder[Model](model: Model, updated: Boolean)


### PR DESCRIPTION
Previously, the render loop was running on every animation frame in the browser. Now, then render loop waits until there has been at least one update to the model before re-starting the render cycle.