### PR TITLE
Reworking the runtime

### DIFF
--- a/tyrian/js/src/main/scala/tyrian/runtime/ModelHolder.scala
+++ b/tyrian/js/src/main/scala/tyrian/runtime/ModelHolder.scala
@@ -1,3 +1,0 @@
-package tyrian.runtime
-
-final case class ModelHolder[Model](model: Model, updated: Boolean)

--- a/tyrian/js/src/main/scala/tyrian/runtime/Renderer.scala
+++ b/tyrian/js/src/main/scala/tyrian/runtime/Renderer.scala
@@ -1,0 +1,89 @@
+package tyrian.runtime
+
+import cats.effect.kernel.Async
+import cats.effect.kernel.Clock
+import cats.effect.kernel.Ref
+import cats.effect.std.Dispatcher
+import cats.syntax.all.*
+import org.scalajs.dom
+import snabbdom.VNode
+import tyrian.Html
+import tyrian.Location
+
+final case class Renderer(vnode: VNode, state: RendererState):
+
+  def runningAt(t: Long): Renderer =
+    this.copy(state = RendererState.Running(t))
+
+object Renderer:
+
+  def init[F[_]](vnode: VNode)(using F: Async[F]): F[Ref[F, Renderer]] =
+    F.ref(
+      Renderer(vnode, RendererState.Idle)
+    )
+
+  private val timeout: Long = 1000
+
+  // This function gets called on every model update
+  def redraw[F[_], Model, Msg](
+      dispatcher: Dispatcher[F],
+      renderer: Ref[F, Renderer],
+      model: Ref[F, Model],
+      view: Model => Html[Msg],
+      onMsg: Msg => Unit,
+      router: Location => Msg
+  )(using F: Async[F], clock: Clock[F]): F[Unit] =
+    clock.realTime.flatMap { time =>
+      renderer.modify { r =>
+        r.state match
+          case RendererState.Idle =>
+            // If the render state is idle, update the last triggered time and begin.
+            r.runningAt(time.toMillis) ->
+              F.delay(
+                dom.window.requestAnimationFrame(_ =>
+                  render(dispatcher, renderer, model, view, onMsg, router)(time.toMillis)
+                )
+              ).void
+
+          case RendererState.Running(_) =>
+            // If the render state is running, just update the triggered time.
+            r.runningAt(time.toMillis) -> F.unit
+      }
+    }.flatten
+
+  private def render[F[_], Model, Msg](
+      dispatcher: Dispatcher[F],
+      renderer: Ref[F, Renderer],
+      model: Ref[F, Model],
+      view: Model => Html[Msg],
+      onMsg: Msg => Unit,
+      router: Location => Msg
+  )(t: Long)(using F: Async[F], clock: Clock[F]): Unit =
+    dispatcher.unsafeRunAndForget {
+      for {
+        time <- clock.realTime.map(_.toMillis)
+        m    <- model.get
+
+        res <- renderer.modify { r =>
+          r.state match
+            case RendererState.Idle =>
+              // Something has gone wrong, do nothing.
+              r -> F.unit
+
+            case RendererState.Running(lastTriggered) =>
+              // If nothing has happened, set to idle and do not loop
+              if t - lastTriggered >= timeout then r.copy(state = RendererState.Idle) -> F.unit
+              else
+                // Otherwise, re-render and set the state appropriately
+                r.copy(
+                  vnode = Rendering.render(r.vnode, m, view, onMsg, router)
+                ) ->
+                  F.delay(
+                    // Loop
+                    dom.window.requestAnimationFrame(_ =>
+                      render(dispatcher, renderer, model, view, onMsg, router)(time)
+                    )
+                  ).void
+        }.flatten
+      } yield res
+    }

--- a/tyrian/js/src/main/scala/tyrian/runtime/RendererState.scala
+++ b/tyrian/js/src/main/scala/tyrian/runtime/RendererState.scala
@@ -1,0 +1,5 @@
+package tyrian.runtime
+
+enum RendererState derives CanEqual:
+  case Idle
+  case Running(lastTriggered: Long)

--- a/tyrian/js/src/main/scala/tyrian/runtime/Rendering.scala
+++ b/tyrian/js/src/main/scala/tyrian/runtime/Rendering.scala
@@ -3,20 +3,9 @@ package tyrian.runtime
 import org.scalajs.dom
 import org.scalajs.dom.Element
 import org.scalajs.dom.window
-import snabbdom._
-import snabbdom.modules._
-import tyrian.Attr
-import tyrian.Attribute
-import tyrian.Empty
-import tyrian.Event
-import tyrian.Html
-import tyrian.Location
-import tyrian.NamedAttribute
-import tyrian.PropertyBoolean
-import tyrian.PropertyString
-import tyrian.RawTag
-import tyrian.Tag
-import tyrian.Text
+import snabbdom.*
+import snabbdom.modules.*
+import tyrian.*
 
 import scala.scalajs.js
 


### PR DESCRIPTION
This PR may not survive, I'm just using it so it's easier for me to check my own work.

So far I've done some refactoring. No suggestion that this is an improvement, but the exercise has helped me reacquaint myself with what's going on.

The idea is to do the following, from the [issue comment](https://github.com/PurpleKingdomGames/tyrian/issues/254#issuecomment-2019863143):

> In this model you render on requestAnimationFrame, as long as you saw a message in the last, say, ~2 seconds. So if your app is idle, the rendering will go idle, but while stuff is happening (whether triggered by the user or anything else) the rendering continues.

Rough plan of attack:

Step 1 - Update pokes the renderer:

- Remove ModelHolder
- A model update triggers redraw
- Redraw is on a Renderer class and returns a new instance (to be stored in a Ref?)
- Render has a finite state machine: Idle, Running
- When a redraw happens you record a timestamp, update the state to running (always, for now), then immediately render

Step 2 - Render runs on a loop (again):

- Instead of the update poking the renderer and a render being triggered, it instead checks:  if running do nothing, if not running, start render loop and set state to running
- Render loop checks if < 2 seconds since last update, if true, loop, else state to idle and don't loop.

Something like that.