### PR TITLE
Refactor FileReader to fix side-effect and provide extra context

### DIFF
--- a/tyrian/src/main/scala/tyrian/cmds/FileReader.scala
+++ b/tyrian/src/main/scala/tyrian/cmds/FileReader.scala
@@ -7,6 +7,7 @@ import org.scalajs.dom.document
 import org.scalajs.dom.html
 import tyrian.Cmd
 
+import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.scalajs.js
 import scala.scalajs.js.typedarray
@@ -16,103 +17,88 @@ import scala.scalajs.js.typedarray
   */
 object FileReader:
 
+  val readImageCast: Result[js.Any] => Result[String] =
+    case Result.Error(msg)  => Result.Error(msg)
+    case Result.NoFile(msg) => Result.NoFile(msg)
+    case Result.File(n, p, d) =>
+      try Result.File(n, p, d.asInstanceOf[String])
+      catch case _ => Result.Error("File is not a base64 string of image data")
+
+  val readTextCast: Result[js.Any] => Result[String] =
+    case Result.Error(msg)  => Result.Error(msg)
+    case Result.NoFile(msg) => Result.NoFile(msg)
+    case Result.File(n, p, d) =>
+      try Result.File(n, p, d.asInstanceOf[String])
+      catch case _ => Result.Error("File is not text")
+
+  val readBytesCast: Result[js.Any] => Result[IArray[Byte]] =
+    case Result.Error(msg)  => Result.Error(msg)
+    case Result.NoFile(msg) => Result.NoFile(msg)
+    case Result.File(n, p, d) =>
+      try Result.File(n, p, IArray.from(new typedarray.Int8Array(d.asInstanceOf[typedarray.ArrayBuffer])))
+      catch case _ => Result.Error("Could not cast loaded file data to byte array")
+
   /** Reads an input file from an input field as base64 encoded image data */
   def readImage[F[_]: Async, Msg](inputFieldId: String)(resultToMessage: Result[String] => Msg): Cmd[F, Msg] =
-    val cast: Result[js.Any] => Result[String] =
-      case Result.Error(msg) => Result.Error(msg)
-      case Result.File(n, p, d) =>
-        try Result.File(n, p, d.asInstanceOf[String])
-        catch case _ => Result.Error("File is not a base64 string of image data")
-
-    readFromInputField(inputFieldId, ReadType.AsDataUrl)(cast andThen resultToMessage)
+    readFile(inputFieldId, ReadType.AsDataUrl)(readImageCast andThen resultToMessage)
 
   /** Reads an input file as base64 encoded image data */
   def readImage[F[_]: Async, Msg](file: dom.File)(resultToMessage: Result[String] => Msg): Cmd[F, Msg] =
-    val cast: Result[js.Any] => Result[String] =
-      case Result.Error(msg) => Result.Error(msg)
-      case Result.File(n, p, d) =>
-        try Result.File(n, p, d.asInstanceOf[String])
-        catch case _ => Result.Error("File is not a base64 string of image data")
-
-    readFile(file, ReadType.AsDataUrl)(cast andThen resultToMessage)
+    readFile(file, ReadType.AsDataUrl)(readImageCast andThen resultToMessage)
 
   /** Reads an input file from an input field as plain text */
   def readText[F[_]: Async, Msg](inputFieldId: String)(resultToMessage: Result[String] => Msg): Cmd[F, Msg] =
-    val cast: Result[js.Any] => Result[String] =
-      case Result.Error(msg) => Result.Error(msg)
-      case Result.File(n, p, d) =>
-        try Result.File(n, p, d.asInstanceOf[String])
-        catch case _ => Result.Error("File is not text")
-
-    readFromInputField(inputFieldId, ReadType.AsText)(cast andThen resultToMessage)
+    readFile(inputFieldId, ReadType.AsText)(readTextCast andThen resultToMessage)
 
   /** Reads an input file as plain text */
   def readText[F[_]: Async, Msg](file: dom.File)(resultToMessage: Result[String] => Msg): Cmd[F, Msg] =
-    val cast: Result[js.Any] => Result[String] =
-      case Result.Error(msg) => Result.Error(msg)
-      case Result.File(n, p, d) =>
-        try Result.File(n, p, d.asInstanceOf[String])
-        catch case _ => Result.Error("File is not text")
-
-    readFile(file, ReadType.AsText)(cast andThen resultToMessage)
+    readFile(file, ReadType.AsText)(readTextCast andThen resultToMessage)
 
   /** Reads an input file from an input field as bytes */
   def readBytes[F[_]: Async, Msg](inputFieldId: String)(resultToMessage: Result[IArray[Byte]] => Msg): Cmd[F, Msg] =
-    val cast: Result[js.Any] => Result[IArray[Byte]] =
-      case Result.Error(msg) => Result.Error(msg)
-      case Result.File(n, p, d) =>
-        try Result.File(n, p, IArray.from(new typedarray.Int8Array(d.asInstanceOf[typedarray.ArrayBuffer])))
-        catch case _ => Result.Error("Could not cast loaded file data to byte array")
-
-    readFromInputField(inputFieldId, ReadType.AsArrayBuffer)(cast andThen resultToMessage)
+    readFile(inputFieldId, ReadType.AsArrayBuffer)(readBytesCast andThen resultToMessage)
 
   /** Reads an input file as bytes */
   def readBytes[F[_]: Async, Msg](file: dom.File)(resultToMessage: Result[IArray[Byte]] => Msg): Cmd[F, Msg] =
-    val cast: Result[js.Any] => Result[IArray[Byte]] =
-      case Result.Error(msg) => Result.Error(msg)
-      case Result.File(n, p, d) =>
-        try Result.File(n, p, IArray.from(new typedarray.Int8Array(d.asInstanceOf[typedarray.ArrayBuffer])))
-        catch case _ => Result.Error("Could not cast loaded file data to byte array")
+    readFile(file, ReadType.AsArrayBuffer)(readBytesCast andThen resultToMessage)
 
-    readFile(file, ReadType.AsArrayBuffer)(cast andThen resultToMessage)
-
-  private def readFromInputField[F[_]: Async, Msg](fileInputFieldId: String, readType: ReadType)(
-      resultToMessage: Result[js.Any] => Msg
-  ): Cmd[F, Msg] =
-    val files = document.getElementById(fileInputFieldId).asInstanceOf[html.Input].files
-    if files.length == 0 then Cmd.None
-    else readFile(files.item(0), readType)(resultToMessage)
-
-  private def readFile[F[_]: Async, Msg](file: dom.File, readAsType: ReadType)(
+  private def readFile[F[_]: Async, Msg](fileOrInputId: dom.File | String, readAsType: ReadType)(
       resultToMessage: Result[js.Any] => Msg
   ): Cmd[F, Msg] =
     val task = Async[F].delay {
-      val p          = Promise[Result[js.Any]]()
-      val fileReader = new dom.FileReader()
-      fileReader.addEventListener(
-        "load",
-        (e: Event) =>
-          p.success(
-            Result.File(
-              name = file.name,
-              path = readAsType match
-                case ReadType.AsDataUrl => e.target.asInstanceOf[js.Dynamic].result.asInstanceOf[String]
-                case _                  => ""
-              ,
-              data = fileReader.result
-            )
-          ),
-        false
-      )
-      fileReader.onerror = _ => p.success(Result.Error(s"Error reading from file"))
+      val maybeFile = fileOrInputId match
+        case f: dom.File => Some(f)
+        case inputId: String =>
+          document.getElementById(inputId).asInstanceOf[html.Input].files.headOption
+      maybeFile match
+        case None => Future.successful(Result.NoFile("No files on specified input"))
+        case Some(file) =>
+          val p          = Promise[Result[js.Any]]()
+          val fileReader = new dom.FileReader()
+          fileReader.addEventListener(
+            "load",
+            (e: Event) =>
+              p.success(
+                Result.File(
+                  name = file.name,
+                  path = readAsType match
+                    case ReadType.AsDataUrl => e.target.asInstanceOf[js.Dynamic].result.asInstanceOf[String]
+                    case _                  => ""
+                  ,
+                  data = fileReader.result
+                )
+              ),
+            false
+          )
+          fileReader.onerror = _ => p.success(Result.Error(s"Error reading from file"))
 
-      readAsType match
-        case ReadType.AsText => fileReader.readAsText(file)
-        case ReadType.AsArrayBuffer =>
-          fileReader.readAsArrayBuffer(file)
-        case ReadType.AsDataUrl => fileReader.readAsDataURL(file)
+          readAsType match
+            case ReadType.AsText => fileReader.readAsText(file)
+            case ReadType.AsArrayBuffer =>
+              fileReader.readAsArrayBuffer(file)
+            case ReadType.AsDataUrl => fileReader.readAsDataURL(file)
 
-      p.future
+          p.future
     }
 
     Cmd.Run(Async[F].fromFuture(task), resultToMessage)
@@ -125,3 +111,4 @@ object FileReader:
   enum Result[A]:
     case Error(message: String)
     case File(name: String, path: String, data: A)
+    case NoFile(message: String)


### PR DESCRIPTION
Found this unexpected behavior when using the FileReader by defining a `Cmd` as a Scala `val`.

The code to read the `dom.File` from an input element by ID executes eagerly, before returning the final suspended `Cmd` for reading a file. This means that if you use this helper in your code as a `val` it will get the result at definition time, and not when you actually expect the `Cmd` to execute.

To fix this, I made the following changes:
* `readFile` now takes a parameter to get the `dom.File` input so that it can be provided multiple ways.
* There is a new `Result.NoFile` type that is a variant of `Result.Error` but providing the additional context that there is no file specified. This can be useful for more precise application error messages in addition to making refactoring easier.
* I extracted the `cast` functions in each helper method to their own values so the file size is smaller and it's easier to keep these in sync if their behavior should ever change.

Hope this change meets your standards and thanks again for the wonderful project!