### PR TITLE
Support scala-js-snabbdom-0.2.0-M3 and lazy property setting

### DIFF
--- a/docs/02-guides/html.md
+++ b/docs/02-guides/html.md
@@ -145,3 +145,23 @@ One occasion where you may need to make your own tags or attributes etc., is whe
 A previous case of this was where the input field `value` `property` was incorrectly declared as an `attribute`, and so the value wasn't changed as expected based on model updates.
 
 Effort has gone in to getting these things right, but if you come across any issues, [please report them](https://github.com/PurpleKingdomGames/tyrian/issues), and the workaround is to re-declare it yourself as above while a fix is produced.
+
+#### Known Gotcha: Eager Property Setting
+
+It's possible that sometimes properties of elements will appear inconsistently applied due to how changes are applied to the DOM.
+For example, if you have a `select` element that is regularly changing its `option` children as well as its `value` property at the same time, you might occasionally see the selected value be inaccurate.
+
+You can hint to Tyrian that you would like it to delay setting properties on a particular element until after other elements have been updated by using the `.setLazy` method on any `Html` element:
+
+```scala mdoc:js
+val myValue = "test-value"
+val myElem = select(value := myValue)(
+  option(value := "test-value")("Test Value"),
+  option(value := "other-value")("Other Value")
+)
+
+// In this case, applies the `value` property after the rest of the page finishes rendering
+myElem.setLazy
+```
+
+You will typically not need to do this for most elements, but it is a useful workaround for some edge cases.

--- a/project/Dependancies.scala
+++ b/project/Dependancies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val scalajsDomVersion = "2.8.0"
   val munitCatsEffect3  = "2.0.0"
   val disciplineMUnit   = "2.0.0"
-  val scalajsSnabbdom   = "0.1.0"
+  val scalajsSnabbdom   = "0.2.0-M3"
   val zio               = "2.1.7"
   val zioInteropCats    = "23.1.0.3"
   val scalaJavaTime     = "2.6.0"

--- a/tyrian-tags/shared/src/main/scala/tyrian/Html.scala
+++ b/tyrian-tags/shared/src/main/scala/tyrian/Html.scala
@@ -34,7 +34,9 @@ sealed trait Html[+M] extends Elem[M]:
   /** Clear a key value that was being used to help the virtual-dom understand what has changed. */
   def clearKey: Html[M]
 
-  /** Set this node to apply attribute and property changes later, after the rest of the page has finished updating. */
+  /** Set this node to apply property changes later, after the rest of the page has finished updating. Only use this if
+    * you are experiencing strange behavior where properties such as 'value' are not updated as you would expect.
+    */
   def setLazy: Html[M]
 
   override def toString(): String = this.render

--- a/tyrian/src/main/scala/tyrian/runtime/Renderer.scala
+++ b/tyrian/src/main/scala/tyrian/runtime/Renderer.scala
@@ -6,18 +6,18 @@ import cats.effect.kernel.Ref
 import cats.effect.std.Dispatcher
 import cats.syntax.all.*
 import org.scalajs.dom
-import snabbdom.VNode
+import snabbdom.PatchedVNode
 import tyrian.Html
 import tyrian.Location
 
-final case class Renderer(vnode: VNode, state: RendererState):
+final case class Renderer(vnode: PatchedVNode, state: RendererState):
 
   def runningAt(t: Long): Renderer =
     this.copy(state = RendererState.Running(t))
 
 object Renderer:
 
-  def init[F[_]](vnode: VNode)(using F: Async[F]): F[Ref[F, Renderer]] =
+  def init[F[_]](vnode: PatchedVNode)(using F: Async[F]): F[Ref[F, Renderer]] =
     F.ref(
       Renderer(vnode, RendererState.Idle)
     )

--- a/tyrian/src/main/scala/tyrian/runtime/Rendering.scala
+++ b/tyrian/src/main/scala/tyrian/runtime/Rendering.scala
@@ -41,11 +41,20 @@ object Rendering:
         (n, EventHandler(callback))
       }
 
+    val hooks: Option[Hooks] =
+      Some(Hooks(postpatch = Some { (oldV, newV) =>
+        val elm = oldV.node.asInstanceOf[js.Dictionary[Any]]
+        props.foreach { (k, v) =>
+          elm(k) = v
+        }
+      }))
+
     VNodeData.empty.copy(
       props = props.toMap,
       attrs = as.map((k, v) => k -> AttrValue(v)).toMap,
       on = events.toMap,
-      key = key
+      key = key,
+      hook = hooks
     )
 
   private def interceptHref[Msg](attrs: List[Attr[Msg]]): Boolean =


### PR DESCRIPTION
This PR comes from troubleshooting strange behavior in a webapp I'm making where the value property on some elements could sometimes not appear to update as I'd expect. In trying multiple solutions such as setting keys on the elements I'm updating, the only solution I've found that works is a combination of the following:

* updating scala-js-snabbdom to 0.2.0-M3
* Adding a way to hint to tyrian that you want properties applied later in the rendering process (`Html#setLazy`)

Part of the reason why this works is that the behavior of the `Props` module in scala-js-snabbdom [has changed between versions](https://github.com/buntec/scala-js-snabbdom/compare/v0.1.0..v0.2.0-M3#diff-f1c471db1a0dcc4fe670fdde143206e9be24f72721febc79b7eb28407ae71dc6). In particular it no longer filters out the `value` property on updates. Trying to add `setLazy` to the branch supporting v0.1.0 does not fix the issue.

The way this is meant to work is, you will add `.setLazy` onto any elements that are exhibiting strange property-setting behavior, to delay setting those properties until after every other element is updated. If it's added to a normal element, it may change behavior, so it's only meant to be used in strange edge-cases where values or other properties appear as if they are not correctly being set.

Alternatively -- if you can think of a more elegant way to solve the issues I've been experiencing without this kind of hack-ish solution, or without supporting a milestone-version of this library, I would love to hear it. I'm personally a bit nervous about this requiring a milestone version of scala-js-snabbdom and it has not been updated in quite some time. That being said, the behavior has not actually changed all that much from v0.1.0 from the looks of things and everything else appears to work as I'd expect so far, so YMMV.