### PR TITLE
Convert Future to Async

### DIFF
--- a/tyrian/src/main/scala/tyrian/cmds/ImageLoader.scala
+++ b/tyrian/src/main/scala/tyrian/cmds/ImageLoader.scala
@@ -15,8 +15,6 @@ object ImageLoader:
     val task: F[Result] =
       Async[F].async { callback =>
         Async[F].delay {
-          println("Used ImageLoader!")
-
           val image: html.Image = document.createElement("img").asInstanceOf[html.Image]
           image.src = path
           image.onload = { (_: Event) =>


### PR DESCRIPTION
Resolves #280 

There were 3 similar instances where scala Future/Promises were being used and all of them were similarly converted to `Async[F].async`. I didn't find test cases for these but the file readers at least are "covered" in the sandbox project where I could confirm they still work without issues. I added yet another contrived example in the Sandbox for the `ImageLoader`, which wasn't being used anywhere so far, and I'm not entirely sure it's the correct use case for it but at least I can see that it works fine.