### PR TITLE
Fixed #272: Better support for query params

### DIFF
--- a/tyrian-tags/shared/src/main/scala/tyrian/LocationDetails.scala
+++ b/tyrian-tags/shared/src/main/scala/tyrian/LocationDetails.scala
@@ -1,5 +1,8 @@
 package tyrian
 
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
 /** Represents the deconstructed parts of a url.
   *
   * @param hash
@@ -23,7 +26,7 @@ final case class LocationDetails(
     pathName: String,
     port: Option[String],
     protocol: Option[String],
-    search: Option[String],
+    search: LocationDetails.SearchParams,
     url: String
 ):
   private val noSep = List("xmpp:", "data:", "mailto:")
@@ -86,10 +89,25 @@ object LocationDetails:
       case _ =>
         LocationPathDetails(path, None, None)
 
+  def parseQueryParams(rawQuery: String): SearchParams =
+    val decoded = URLDecoder.decode(rawQuery, StandardCharsets.UTF_8.name())
+    if decoded.startsWith("?") then
+      val values = decoded.drop(1)
+      SearchParams(
+        values.split("&").toList.flatMap { param =>
+          param.split("=", 2).toList match
+            case key :: value :: Nil => List(QueryParam.Pair(key, value))
+            case key :: Nil          => List(QueryParam.KeyOnly(key))
+            case _                   => Nil
+        }
+      )
+    else SearchParams.empty
+
   def fromUrl(url: String): LocationDetails =
     url match
       case urlFileMatch(protocol, path) =>
         val p = parsePath(Option(path).getOrElse(""))
+        val q = p.search.map(parseQueryParams).getOrElse(LocationDetails.SearchParams.empty)
 
         LocationDetails(
           hash = p.hash,
@@ -97,12 +115,13 @@ object LocationDetails:
           pathName = p.path,
           port = None,
           protocol = Option(protocol),
-          search = p.search,
+          search = q,
           url = url
         )
 
       case urlDataMatch(protocol, path) =>
         val p = parsePath(Option(path).getOrElse(""))
+        val q = p.search.map(parseQueryParams).getOrElse(LocationDetails.SearchParams.empty)
 
         LocationDetails(
           hash = p.hash,
@@ -110,12 +129,13 @@ object LocationDetails:
           pathName = p.path,
           port = None,
           protocol = Option(protocol),
-          search = p.search,
+          search = q,
           url = url
         )
 
       case urlMatch(protocol, _, hostname, _, port, path) =>
         val p = parsePath(Option(path).getOrElse(""))
+        val q = p.search.map(parseQueryParams).getOrElse(LocationDetails.SearchParams.empty)
 
         LocationDetails(
           hash = p.hash,
@@ -123,12 +143,13 @@ object LocationDetails:
           pathName = p.path,
           port = Option(port),
           protocol = Option(protocol),
-          search = p.search,
+          search = q,
           url = url
         )
 
       case pathOnly =>
         val p = parsePath(Option(pathOnly).getOrElse(""))
+        val q = p.search.map(parseQueryParams).getOrElse(LocationDetails.SearchParams.empty)
 
         LocationDetails(
           hash = p.hash,
@@ -136,8 +157,56 @@ object LocationDetails:
           pathName = p.path,
           port = None,
           protocol = None,
-          search = p.search,
+          search = q,
           url = url
         )
 
   final case class LocationPathDetails(path: String, search: Option[String], hash: Option[String])
+
+  final case class SearchParams(params: List[QueryParam]):
+    def find(key: String): List[QueryParam] =
+      params.filter(_.key == key)
+
+    def hasKey(key: String): Boolean =
+      params.exists(_.key == key)
+
+    def keys: List[String] =
+      params.map(_.key)
+
+    def toTuples: List[(String, String)] =
+      params.map {
+        case QueryParam.KeyOnly(_key)     => (_key, "")
+        case QueryParam.Pair(_key, value) => (_key, value)
+      }
+
+    def valueOf(key: String): List[String] =
+      find(key).flatMap(_.valueOpt.toList)
+
+  object SearchParams:
+    val empty: SearchParams =
+      SearchParams(Nil)
+
+    def apply(params: QueryParam*): SearchParams =
+      SearchParams(params.toList)
+
+  enum QueryParam(val key: String) derives CanEqual:
+    case KeyOnly(_key: String)             extends QueryParam(_key)
+    case Pair(_key: String, value: String) extends QueryParam(_key)
+
+    def valueOpt: Option[String] =
+      this match
+        case KeyOnly(_key)     => None
+        case Pair(_key, value) => Some(value)
+
+    def toTuple: (String, String) =
+      this match
+        case KeyOnly(_key)     => (_key, "")
+        case Pair(_key, value) => (_key, value)
+
+  object QueryParam:
+
+    def apply(key: String, value: String): QueryParam =
+      QueryParam.Pair(key, value)
+
+    def apply(key: String): QueryParam =
+      QueryParam.KeyOnly(key)

--- a/tyrian-tags/shared/src/test/scala/tyrian/LocationTests.scala
+++ b/tyrian-tags/shared/src/test/scala/tyrian/LocationTests.scala
@@ -14,7 +14,7 @@ class LocationTests extends munit.FunSuite:
             pathName = "/",
             port = None,
             protocol = None,
-            search = None,
+            search = LocationDetails.SearchParams.empty,
             url = "/"
           )
         )
@@ -28,7 +28,7 @@ class LocationTests extends munit.FunSuite:
           pathName = "/page4",
           port = None,
           protocol = None,
-          search = None,
+          search = LocationDetails.SearchParams.empty,
           url = "/page4"
         )
       )
@@ -53,7 +53,7 @@ class LocationTests extends munit.FunSuite:
           pathName = "/page4",
           port = Some("8080"),
           protocol = Some("https:"),
-          search = None,
+          search = LocationDetails.SearchParams.empty,
           url = "https://localhost:8080/page4"
         )
       )
@@ -78,7 +78,7 @@ class LocationTests extends munit.FunSuite:
           pathName = "/docs",
           port = None,
           protocol = Some("https:"),
-          search = None,
+          search = LocationDetails.SearchParams.empty,
           url = "https://indigoengine.io/docs"
         )
       )


### PR DESCRIPTION
Allows things like:

```scala
location.search.valueOf("id") // Returns values of all query params with a key of id, in order.
```